### PR TITLE
[Alpha] Enhance RadioTuner with improved visual feedback and styling

### DIFF
--- a/src/components/radio/RadioTuner.css
+++ b/src/components/radio/RadioTuner.css
@@ -91,6 +91,38 @@
   border-radius: 4px;
   top: 50%;
   transform: translateY(-50%);
+  overflow: visible;
+}
+
+.tuner-dial-track::before {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg,
+    transparent 0%, transparent 9.9%,
+    #555 10%, #555 10.1%,
+    transparent 10.1%, transparent 19.9%,
+    #555 20%, #555 20.1%,
+    transparent 20.1%, transparent 29.9%,
+    #555 30%, #555 30.1%,
+    transparent 30.1%, transparent 39.9%,
+    #555 40%, #555 40.1%,
+    transparent 40.1%, transparent 49.9%,
+    #555 50%, #555 50.1%,
+    transparent 50.1%, transparent 59.9%,
+    #555 60%, #555 60.1%,
+    transparent 60.1%, transparent 69.9%,
+    #555 70%, #555 70.1%,
+    transparent 70.1%, transparent 79.9%,
+    #555 80%, #555 80.1%,
+    transparent 80.1%, transparent 89.9%,
+    #555 90%, #555 90.1%,
+    transparent 90.1%, transparent 99.9%,
+    #555 100%, #555 100%
+  );
+  border-radius: 4px;
+  opacity: 0.7;
 }
 
 .tuner-dial-knob {
@@ -158,12 +190,20 @@
 
 .signal-strength-container {
   margin: 20px 0;
+  position: relative;
 }
 
 .signal-strength-label {
   font-size: 0.9rem;
   color: #aaa;
   margin-bottom: 5px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.signal-strength-value {
+  color: #0f0;
+  font-weight: bold;
 }
 
 .signal-strength-meter {
@@ -172,12 +212,62 @@
   background-color: #333;
   border-radius: 4px;
   overflow: hidden;
+  position: relative;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.5);
 }
 
 .signal-strength-fill {
   height: 100%;
   background: linear-gradient(90deg, #f00, #ff0, #0f0);
   transition: width 0.3s ease;
+  position: relative;
+  box-shadow: 0 0 10px rgba(0, 255, 0, 0.5);
+}
+
+.signal-strength-fill::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(to bottom,
+    rgba(255, 255, 255, 0.3) 0%,
+    rgba(255, 255, 255, 0.1) 50%,
+    rgba(0, 0, 0, 0.1) 51%,
+    rgba(0, 0, 0, 0.2) 100%);
+}
+
+.signal-strength-ticks {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 2px;
+  pointer-events: none;
+}
+
+.signal-strength-tick {
+  width: 1px;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+}
+
+.signal-strength-pulse {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  bottom: -2px;
+  width: 4px;
+  background-color: #0f0;
+  border-radius: 2px;
+  box-shadow: 0 0 8px #0f0;
+  animation: pulse 1s infinite;
+  opacity: 0;
+  transition: opacity 0.3s ease;
 }
 
 .tuner-controls {
@@ -259,6 +349,8 @@
   font-size: 1rem;
   cursor: pointer;
   transition: all 0.2s;
+  position: relative;
+  overflow: hidden;
 }
 
 .scan-button:hover {
@@ -277,6 +369,27 @@
   animation: pulse 1s infinite;
 }
 
+.scan-button.scanning::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.2),
+    transparent
+  );
+  animation: scanning 2s infinite;
+}
+
+@keyframes scanning {
+  0% { left: -100%; }
+  100% { left: 100%; }
+}
+
 @keyframes pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.7; }
@@ -287,42 +400,105 @@
   flex-direction: column;
   align-items: center;
   gap: 5px;
+  position: relative;
 }
 
 .noise-type-control label {
   font-size: 0.8rem;
   color: #aaa;
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
 .noise-type-control select {
-  background-color: #333;
-  color: #fff;
+  background-color: #222;
+  color: #0f0;
   border: 1px solid #444;
   border-radius: 4px;
-  padding: 4px 8px;
+  padding: 6px 24px 6px 10px;
   font-size: 0.9rem;
   cursor: pointer;
   outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: linear-gradient(45deg, transparent 50%, #0f0 50%),
+                    linear-gradient(135deg, #0f0 50%, transparent 50%);
+  background-position: calc(100% - 13px) 50%, calc(100% - 8px) 50%;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  transition: all 0.2s;
 }
 
 .noise-type-control select:focus {
   border-color: #0f0;
+  box-shadow: 0 0 0 2px rgba(0, 255, 0, 0.2);
+}
+
+.noise-type-control select:hover {
+  background-color: #2a2a2a;
 }
 
 .noise-type-control select option {
   background-color: #222;
   color: #fff;
+  padding: 8px;
 }
 
-/* Add some frequency markers */
-.tuner-dial-container::before {
+.noise-type-control::after {
   content: '';
   position: absolute;
-  width: 100%;
-  height: 10px;
-  bottom: -20px;
+  bottom: -2px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 2px;
+  background-color: #0f0;
+  transition: width 0.3s ease;
+}
+
+.noise-type-control:hover::after {
+  width: 80%;
+}
+
+/* Frequency markers */
+.frequency-markers {
   display: flex;
   justify-content: space-between;
+  width: 100%;
+  margin-top: 5px;
+  padding: 0 12px;
+  box-sizing: border-box;
+  position: relative;
+}
+
+.frequency-marker {
+  font-size: 0.7rem;
+  color: #888;
+  position: relative;
+  width: 1px;
+}
+
+.frequency-marker::before {
+  content: '';
+  position: absolute;
+  height: 8px;
+  width: 1px;
+  background-color: #555;
+  top: -12px;
+  left: 0;
+}
+
+.frequency-marker.major {
+  color: #aaa;
+  font-weight: bold;
+}
+
+.frequency-marker.major::before {
+  height: 12px;
+  width: 2px;
+  background-color: #777;
+  top: -16px;
 }
 
 /* Static visualization */
@@ -347,6 +523,19 @@
   opacity: 0.5;
   mix-blend-mode: screen;
   transition: opacity 0.3s ease;
+  filter: contrast(1.2) brightness(1.1);
+}
+
+.static-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: radial-gradient(circle at center, transparent 30%, rgba(0, 0, 0, 0.3) 100%);
+  pointer-events: none;
+  z-index: 11;
+  mix-blend-mode: overlay;
 }
 
 /* Add some static/noise effect when signal is weak */

--- a/src/components/radio/RadioTuner.tsx
+++ b/src/components/radio/RadioTuner.tsx
@@ -155,17 +155,28 @@ const RadioTuner: React.FC<RadioTunerProps> = ({
 
     // Only draw static if radio is on
     if (state.isRadioOn) {
-      // Draw static noise
+      // Draw static noise with color variations based on signal strength
       const intensity = staticIntensity * 255;
       const imageData = ctx.createImageData(canvas.width, canvas.height);
       const data = imageData.data;
 
+      // Add color tint based on signal strength
+      const signalColor = {
+        r: signalStrength > 0.7 ? 0 : 255 * (1 - signalStrength),
+        g: signalStrength > 0.3 ? 255 * signalStrength : 0,
+        b: signalStrength < 0.3 ? 255 * (1 - signalStrength) : 0
+      };
+
       for (let i = 0; i < data.length; i += 4) {
-        const noise = Math.random() * intensity;
-        data[i] = noise; // R
-        data[i + 1] = noise; // G
-        data[i + 2] = noise; // B
-        data[i + 3] = Math.random() * 255 * staticIntensity; // A
+        // Create more varied noise pattern
+        const noisePattern = Math.random() < 0.3 ? 0 : Math.random() * intensity;
+        const colorVariation = Math.random() * 0.3;
+
+        // Apply color tint based on signal strength
+        data[i] = noisePattern + (signalColor.r * colorVariation); // R
+        data[i + 1] = noisePattern + (signalColor.g * colorVariation); // G
+        data[i + 2] = noisePattern + (signalColor.b * colorVariation); // B
+        data[i + 3] = (Math.random() * 200 + 55) * staticIntensity; // A - more varied opacity
       }
 
       ctx.putImageData(imageData, 0, 0);
@@ -179,17 +190,28 @@ const RadioTuner: React.FC<RadioTunerProps> = ({
       // Clear canvas
       ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-      // Draw static noise
+      // Draw static noise with color variations based on signal strength
       const intensity = staticIntensity * 255;
       const imageData = ctx.createImageData(canvas.width, canvas.height);
       const data = imageData.data;
 
+      // Add color tint based on signal strength
+      const signalColor = {
+        r: signalStrength > 0.7 ? 0 : 255 * (1 - signalStrength),
+        g: signalStrength > 0.3 ? 255 * signalStrength : 0,
+        b: signalStrength < 0.3 ? 255 * (1 - signalStrength) : 0
+      };
+
       for (let i = 0; i < data.length; i += 4) {
-        const noise = Math.random() * intensity;
-        data[i] = noise; // R
-        data[i + 1] = noise; // G
-        data[i + 2] = noise; // B
-        data[i + 3] = Math.random() * 255 * staticIntensity; // A
+        // Create more varied noise pattern
+        const noisePattern = Math.random() < 0.3 ? 0 : Math.random() * intensity;
+        const colorVariation = Math.random() * 0.3;
+
+        // Apply color tint based on signal strength
+        data[i] = noisePattern + (signalColor.r * colorVariation); // R
+        data[i + 1] = noisePattern + (signalColor.g * colorVariation); // G
+        data[i + 2] = noisePattern + (signalColor.b * colorVariation); // B
+        data[i + 3] = (Math.random() * 200 + 55) * staticIntensity; // A - more varied opacity
       }
 
       ctx.putImageData(imageData, 0, 0);
@@ -360,6 +382,12 @@ const RadioTuner: React.FC<RadioTunerProps> = ({
           }}
           aria-hidden="true"
         />
+        <div
+          className="static-overlay"
+          style={{
+            opacity: state.isRadioOn ? 0.7 : 0,
+          }}
+        />
       </div>
 
       <div
@@ -377,10 +405,30 @@ const RadioTuner: React.FC<RadioTunerProps> = ({
         <div className="tuner-dial-track">
           <div className="tuner-dial-knob" style={{ left: `${dialPosition}%` }} />
         </div>
+        <div className="frequency-markers">
+          {Array.from({ length: 11 }, (_, i) => {
+            const markerFrequency = minFrequency + (i * (maxFrequency - minFrequency)) / 10;
+            const isMajor = i % 2 === 0;
+            return (
+              <div
+                key={i}
+                className={`frequency-marker ${isMajor ? 'major' : ''}`}
+                style={{ left: `${i * 10}%` }}
+              >
+                {isMajor && markerFrequency.toFixed(1)}
+              </div>
+            );
+          })}
+        </div>
       </div>
 
       <div className={`signal-strength-container ${!state.isRadioOn ? 'disabled' : ''}`}>
-        <div className="signal-strength-label">Signal Strength</div>
+        <div className="signal-strength-label">
+          <span>Signal Strength</span>
+          <span className="signal-strength-value">
+            {state.isRadioOn ? `${Math.round(signalStrength * 100)}%` : '0%'}
+          </span>
+        </div>
         <div
           className="signal-strength-meter"
           role="progressbar"
@@ -392,6 +440,15 @@ const RadioTuner: React.FC<RadioTunerProps> = ({
           <div
             className="signal-strength-fill"
             style={{ width: `${state.isRadioOn ? signalStrength * 100 : 0}%` }}
+          />
+          <div className="signal-strength-ticks">
+            {Array.from({ length: 10 }, (_, i) => (
+              <div key={i} className="signal-strength-tick" />
+            ))}
+          </div>
+          <div
+            className="signal-strength-pulse"
+            style={{ opacity: currentSignalId && signalStrength > 0.5 ? 1 : 0 }}
           />
         </div>
       </div>


### PR DESCRIPTION
## Description
This PR enhances the visual aspects of the RadioTuner component without interfering with the core functionality or type system.

### Changes
- Added frequency markers to the tuner dial for better visual feedback
- Enhanced the static visualization with more realistic noise patterns and color variations based on signal strength
- Improved the signal strength meter with better visual indicators and a pulsing effect when a signal is detected
- Enhanced button and control styling, particularly the scan button and noise type selector

### Testing
These changes are purely visual and do not affect the core functionality of the RadioTuner component. The existing tests should continue to pass.

### Screenshots
(Screenshots will be added in the PR comments)

### Notes for Agent Beta
These changes do not affect the interface contracts between Alpha and Beta components. The RadioTuner component still maintains the same API and behavior, just with improved visual feedback.