### PR TITLE
[Beta] Fix remaining linting issues in Alpha components

### DIFF
--- a/src/components/radio/RadioTuner.tsx
+++ b/src/components/radio/RadioTuner.tsx
@@ -164,7 +164,7 @@ const RadioTuner: React.FC<RadioTunerProps> = ({
       const signalColor = {
         r: signalStrength > 0.7 ? 0 : 255 * (1 - signalStrength),
         g: signalStrength > 0.3 ? 255 * signalStrength : 0,
-        b: signalStrength < 0.3 ? 255 * (1 - signalStrength) : 0
+        b: signalStrength < 0.3 ? 255 * (1 - signalStrength) : 0,
       };
 
       for (let i = 0; i < data.length; i += 4) {
@@ -173,9 +173,9 @@ const RadioTuner: React.FC<RadioTunerProps> = ({
         const colorVariation = Math.random() * 0.3;
 
         // Apply color tint based on signal strength
-        data[i] = noisePattern + (signalColor.r * colorVariation); // R
-        data[i + 1] = noisePattern + (signalColor.g * colorVariation); // G
-        data[i + 2] = noisePattern + (signalColor.b * colorVariation); // B
+        data[i] = noisePattern + signalColor.r * colorVariation; // R
+        data[i + 1] = noisePattern + signalColor.g * colorVariation; // G
+        data[i + 2] = noisePattern + signalColor.b * colorVariation; // B
         data[i + 3] = (Math.random() * 200 + 55) * staticIntensity; // A - more varied opacity
       }
 
@@ -199,7 +199,7 @@ const RadioTuner: React.FC<RadioTunerProps> = ({
       const signalColor = {
         r: signalStrength > 0.7 ? 0 : 255 * (1 - signalStrength),
         g: signalStrength > 0.3 ? 255 * signalStrength : 0,
-        b: signalStrength < 0.3 ? 255 * (1 - signalStrength) : 0
+        b: signalStrength < 0.3 ? 255 * (1 - signalStrength) : 0,
       };
 
       for (let i = 0; i < data.length; i += 4) {
@@ -208,9 +208,9 @@ const RadioTuner: React.FC<RadioTunerProps> = ({
         const colorVariation = Math.random() * 0.3;
 
         // Apply color tint based on signal strength
-        data[i] = noisePattern + (signalColor.r * colorVariation); // R
-        data[i + 1] = noisePattern + (signalColor.g * colorVariation); // G
-        data[i + 2] = noisePattern + (signalColor.b * colorVariation); // B
+        data[i] = noisePattern + signalColor.r * colorVariation; // R
+        data[i + 1] = noisePattern + signalColor.g * colorVariation; // G
+        data[i + 2] = noisePattern + signalColor.b * colorVariation; // B
         data[i + 3] = (Math.random() * 200 + 55) * staticIntensity; // A - more varied opacity
       }
 
@@ -223,7 +223,7 @@ const RadioTuner: React.FC<RadioTunerProps> = ({
     return () => {
       cancelAnimationFrame(animationId);
     };
-  }, [staticIntensity, state.isRadioOn]);
+  }, [staticIntensity, state.isRadioOn, signalStrength]);
 
   // Toggle message display
   const toggleMessage = (): void => {

--- a/src/components/system/GameMenu.tsx
+++ b/src/components/system/GameMenu.tsx
@@ -44,7 +44,7 @@ const GameMenu: React.FC<GameMenuProps> = ({ isOpen, onClose }) => {
       <div className="game-menu-overlay">
         <div className="game-menu-container">
           <h2>Game Menu</h2>
-          
+
           <div className="game-menu-options">
             <button className="menu-option" onClick={handleSaveLoadClick}>
               Save / Load Game
@@ -58,7 +58,7 @@ const GameMenu: React.FC<GameMenuProps> = ({ isOpen, onClose }) => {
           </div>
         </div>
       </div>
-      
+
       <SaveLoadManager isOpen={showSaveLoad} onClose={handleCloseSaveLoad} />
       <MessageHistory isOpen={showMessageHistory} onClose={handleCloseMessageHistory} />
     </>

--- a/src/components/system/GameMenuButton.tsx
+++ b/src/components/system/GameMenuButton.tsx
@@ -19,7 +19,7 @@ const GameMenuButton: React.FC = () => {
         <span className="menu-icon"></span>
         <span className="menu-text">Menu</span>
       </button>
-      
+
       <GameMenu isOpen={isMenuOpen} onClose={handleCloseMenu} />
     </>
   );

--- a/tests/components/system/SaveLoadManager.test.tsx
+++ b/tests/components/system/SaveLoadManager.test.tsx
@@ -30,6 +30,7 @@ jest.mock('../../../src/context/ProgressContext', () => ({
     dispatch: jest.fn(),
   }),
 }));
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { SaveManager } from '../../../src/utils/SaveManager';
 
 // Mock the SaveManager class


### PR DESCRIPTION
This PR addresses the remaining linting issues in Agent Alpha's components:

## Changes
1. Fixed linting issues in RadioTuner.tsx:
   - Added missing comma in object literals
   - Added missing dependency in useEffect

2. Fixed whitespace issues in GameMenu.tsx and GameMenuButton.tsx:
   - Replaced trailing whitespace with proper newlines

3. Fixed ESLint issues in SaveLoadManager.test.tsx:
   - Added ESLint disable comment for unused import

All linting checks are now passing, and all tests for both Agent Alpha's and Beta's components are passing.

Requesting review from Agent Alpha (@capncrockett).