### PR TITLE
[Alpha] Fix infinite update loop in AudioContext and add game ID for E2E tests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,7 @@ const App: React.FC = () => {
     >
       <Router>
         <div className="app-container" data-testid="app-container">
-          <SkipToContent contentId="main-content" />
+          <SkipToContent contentId="game" />
           <GameMenuButton />
           <header className="app-header" data-testid="app-header">
             <h1 data-testid="app-title">Signal Lost</h1>
@@ -73,7 +73,7 @@ const App: React.FC = () => {
               </ul>
             </nav>
           </header>
-          <main className="app-content" id="main-content" data-testid="app-content" tabIndex={-1}>
+          <main className="app-content" id="game" data-testid="app-content" tabIndex={-1}>
             <RouteTransition>
               <Routes>
                 <Route

--- a/src/context/AudioContext.tsx
+++ b/src/context/AudioContext.tsx
@@ -57,7 +57,7 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children }) => {
         newFilter.dispose();
       }
     };
-  }, [noiseNode, oscillator, filter]);
+  }, []); // Empty dependency array to run only on mount/unmount
 
   // Update master volume when volume state changes
   useEffect(() => {

--- a/src/context/AudioContext.tsx
+++ b/src/context/AudioContext.tsx
@@ -27,7 +27,9 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children }) => {
   const [volume, setVolumeState] = useState<number>(0.5);
   const [noiseNode, setNoiseNode] = useState<Tone.Noise | null>(null);
   const [oscillator, setOscillator] = useState<Tone.Oscillator | null>(null);
-  const [filter, setFilter] = useState<Tone.Filter | null>(null);
+  // We need to track the filter state even though it's not directly used in the component
+  // It's used in the playStaticNoise function when a new filter is created
+  const [, setFilter] = useState<Tone.Filter | null>(null);
   const [noiseType, setNoiseType] = useState<NoiseType>(NoiseType.Pink);
   const [noiseGain, setNoiseGain] = useState<Tone.Gain<'gain'> | null>(null);
   const [signalGain, setSignalGain] = useState<Tone.Gain<'gain'> | null>(null);
@@ -57,6 +59,7 @@ export const AudioProvider: React.FC<AudioProviderProps> = ({ children }) => {
         newFilter.dispose();
       }
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Empty dependency array to run only on mount/unmount
 
   // Update master volume when volume state changes


### PR DESCRIPTION
This PR fixes an infinite update loop in the AudioContext component by removing the dependency on state variables in the useEffect cleanup function. It also adds the 'game' ID to the main content element to make E2E tests pass.