### PR TITLE
Fix infinite render loop in radio tuner components

### DIFF
--- a/src/components/radio/BasicRadioTuner.tsx
+++ b/src/components/radio/BasicRadioTuner.tsx
@@ -71,7 +71,9 @@ const BasicRadioTuner: React.FC<RadioTunerProps> = ({
         scanIntervalRef.current = null;
       }
     };
-  }, [audio, dispatch, initialFrequency, state.currentFrequency]);
+    // Only run this effect once on mount and cleanup on unmount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Sync with game state when it changes externally
   useEffect(() => {
@@ -140,10 +142,9 @@ const BasicRadioTuner: React.FC<RadioTunerProps> = ({
       audio.playStaticNoise(intensity);
     }
 
-    // Force a re-render to update the UI
-    forceRender();
+    // DO NOT force a re-render here - this is what causes the infinite loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.isRadioOn, state.discoveredFrequencies, audio, dispatch]);
+  }, [state.isRadioOn, state.discoveredFrequencies, audio, dispatch, state.currentFrequency]);
 
   // Draw static visualization with performance optimizations
   useEffect(() => {
@@ -193,7 +194,7 @@ const BasicRadioTuner: React.FC<RadioTunerProps> = ({
         cancelAnimationFrame(animationId);
       }
     };
-  }, [state.isRadioOn, forceRender]);
+  }, [state.isRadioOn]); // Remove forceRender from dependencies
 
   // Toggle message display
   const toggleMessage = (): void => {

--- a/src/components/radio/SimpleSliderRadioTuner.tsx
+++ b/src/components/radio/SimpleSliderRadioTuner.tsx
@@ -137,6 +137,7 @@ const SimpleSliderRadioTuner: React.FC<RadioTunerProps> = ({
         scanIntervalRef.current = null;
       }
     };
+    // Only run this effect once on mount and cleanup on unmount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -217,8 +218,9 @@ const SimpleSliderRadioTuner: React.FC<RadioTunerProps> = ({
       audio.stopSignal();
       audio.playStaticNoise(intensity);
     }
+    // Include state.currentFrequency in the dependency array to properly track frequency changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.isRadioOn, state.discoveredFrequencies, audio, gameDispatch, localFrequency]);
+  }, [state.isRadioOn, state.discoveredFrequencies, audio, gameDispatch, state.currentFrequency]);
 
   // Handle frequency change from the slider
   const handleSliderChange = (value: number | number[]): void => {


### PR DESCRIPTION
This PR fixes the infinite render loop issue in the radio tuner components by:\n\n1. Removing forceRender calls from useEffect dependencies\n2. Properly setting up the dependency arrays for useEffect hooks\n3. Running initialization effects only once on mount\n\nThese changes should resolve the 'Maximum update depth exceeded' error that was occurring when the radio was turned on.