### PR TITLE
[Alpha] Migrate Godot implementation from GDScript to C#

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,8 @@ mono_crash.*.json
 *.suo
 *.ntvs*
 *.njsproj
-*.sln
+# Allow Godot C# solution files
+# *.sln
 *.sw?
 
 # Logs

--- a/godot_project/README.md
+++ b/godot_project/README.md
@@ -1,16 +1,16 @@
-# Signal Lost - Godot Implementation
+# Signal Lost - Godot C# Implementation
 
-This is the Godot implementation of the Signal Lost game, migrated from the original browser-based React application.
+This is the Godot C# implementation of the Signal Lost game, migrated from the original browser-based React application.
 
 ## Project Structure
 
 - `scenes/` - Contains all game scenes
   - `radio/` - Radio tuner and related scenes
-- `scripts/` - Contains all GDScript files
+- `Scripts/` - Contains all C# script files
 - `assets/` - Contains all game assets
   - `audio/` - Audio files
   - `images/` - Image files
-- `tests/` - Contains all test scripts
+- `Tests/` - Contains all C# test scripts
 
 ## Key Components
 

--- a/godot_project/SignalLost.csproj
+++ b/godot_project/SignalLost.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Godot.NET.Sdk/4.2.1">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <RootNamespace>SignalLost</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/godot_project/SignalLost.sln
+++ b/godot_project/SignalLost.sln
@@ -1,0 +1,19 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SignalLost", "SignalLost.csproj", "{A1C5F9B3-E1F5-4F7C-B589-9F9F2A1A8E5E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+	Debug|Any CPU = Debug|Any CPU
+	ExportDebug|Any CPU = ExportDebug|Any CPU
+	ExportRelease|Any CPU = ExportRelease|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1C5F9B3-E1F5-4F7C-B589-9F9F2A1A8E5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1C5F9B3-E1F5-4F7C-B589-9F9F2A1A8E5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1C5F9B3-E1F5-4F7C-B589-9F9F2A1A8E5E}.ExportDebug|Any CPU.ActiveCfg = ExportDebug|Any CPU
+		{A1C5F9B3-E1F5-4F7C-B589-9F9F2A1A8E5E}.ExportDebug|Any CPU.Build.0 = ExportDebug|Any CPU
+		{A1C5F9B3-E1F5-4F7C-B589-9F9F2A1A8E5E}.ExportRelease|Any CPU.ActiveCfg = ExportRelease|Any CPU
+		{A1C5F9B3-E1F5-4F7C-B589-9F9F2A1A8E5E}.ExportRelease|Any CPU.Build.0 = ExportRelease|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/godot_project/run_tests.bat
+++ b/godot_project/run_tests.bat
@@ -18,7 +18,7 @@ set "DIR=%~dp0"
 echo Project path: %DIR%
 
 REM Run the test runner script
-godot --path "%DIR%" --script tests/test_runner.gd
+godot --path "%DIR%" --script Tests/TestRunner.cs
 
 REM Get the exit code
 set EXIT_CODE=%ERRORLEVEL%

--- a/godot_project/run_tests.sh
+++ b/godot_project/run_tests.sh
@@ -17,7 +17,7 @@ echo "Running tests for Signal Lost Godot project..."
 echo "Project path: $DIR"
 
 # Run the test runner script
-godot --path "$DIR" --script tests/test_runner.gd
+godot --path "$DIR" --script Tests/TestRunner.cs
 
 # Get the exit code
 EXIT_CODE=$?


### PR DESCRIPTION
This PR migrates the Godot implementation from GDScript to C#.

## Changes:

1. Converted all GDScript files to C#:
   - AudioManager.gd → AudioManager.cs
   - GameState.gd → GameState.cs
   - RadioTuner.gd → RadioTuner.cs
   - test_radio_tuner.gd → RadioTunerTests.cs
   - test_runner.gd → TestRunner.cs

2. Added C# project files:
   - SignalLost.csproj
   - SignalLost.sln

3. Updated test runner scripts:
   - run_tests.sh
   - run_tests.bat

4. Updated documentation:
   - godot_project/README.md
   - docs/godot-workflow.md

5. Updated .gitignore to allow C# project files

## Motivation:

We're migrating to C# for Godot development because it's what the team is more familiar with. C# provides stronger type safety and better IDE support, which will help us maintain a high-quality codebase.

## Testing:

The C# implementation has been tested locally and all tests pass. The code structure and functionality remain the same, just converted to C#.