### PR TITLE
Fix missing default_env.tres dependency error

### DIFF
--- a/godot_project/default_env.tres
+++ b/godot_project/default_env.tres
@@ -1,7 +1,10 @@
-[gd_resource type="Environment" load_steps=2 format=3 uid="uid://c8yvxg3xnq6yw"]
+[gd_resource type="Environment" load_steps=3 format=3 uid="uid://bqnqpb0tpwang"]
 
-[sub_resource type="Sky" id="1"]
+[sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_jsa7c"]
+
+[sub_resource type="Sky" id="Sky_0rrj8"]
+material = SubResource("ProceduralSkyMaterial_jsa7c")
 
 [resource]
 background_mode = 2
-sky = SubResource("1")
+sky = SubResource("Sky_0rrj8")


### PR DESCRIPTION
This PR fixes the 'Load failed due to missing dependencies: res://default_env.tres' error that appears when opening the project.

## Problem
When opening the project in Godot, users encounter an error message: 'Load failed due to missing dependencies: res://default_env.tres'. This prevents the project from loading properly.

## Solution
This PR adds a properly formatted default_env.tres file with:
- Proper load_steps value (3)
- ProceduralSkyMaterial and Sky sub-resources
- Correct background_mode and sky settings

## Testing
- Verified that the project loads without errors in the Godot editor
- Verified that the project runs successfully from the command line
- Confirmed that all tests run properly with the new file

## Screenshots
Before:

After:
Project loads without errors.

This is a simple fix that ensures the project can be loaded without errors in both the editor and when running from the command line.