### PR TITLE
Fix RadioTuner UI updates and LogParser partial keyword

### DIFF
--- a/godot_project/LogParser.cs
+++ b/godot_project/LogParser.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 
 namespace SignalLost
 {
-    public class LogParser : Node
+    public partial class LogParser : Node
     {
         public class LogEntry
         {
@@ -35,7 +35,7 @@ namespace SignalLost
         {
             var logEntries = new List<LogEntry>();
             var logsDir = "res://logs";
-            
+
             // Ensure the directory exists
             if (!Directory.Exists(logsDir))
             {
@@ -125,14 +125,14 @@ namespace SignalLost
         public static void PrintErrorSummary()
         {
             var entries = ParseLatestLog();
-            
+
             GD.Print($"Found {entries.Count} log entries");
-            
+
             var errors = entries.Where(e => e.Level == LogEntry.LogLevel.Error || e.Level == LogEntry.LogLevel.ScriptError).ToList();
             var warnings = entries.Where(e => e.Level == LogEntry.LogLevel.Warning).ToList();
-            
+
             GD.Print($"Errors: {errors.Count}, Warnings: {warnings.Count}");
-            
+
             if (errors.Count > 0)
             {
                 GD.Print("\n=== ERRORS ===");
@@ -141,7 +141,7 @@ namespace SignalLost
                     GD.Print(error);
                 }
             }
-            
+
             if (warnings.Count > 0)
             {
                 GD.Print("\n=== WARNINGS ===");

--- a/godot_project/MainScene.tscn
+++ b/godot_project/MainScene.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://c8j6y8o4n8qxv"]
 
-[ext_resource type="PackedScene" uid="uid://c8yvxg3xnq6yw" path="res://tests/audio_visualizer/SimpleAudioVisualizerTestScene.tscn" id="1_r3j2k"]
+[ext_resource type="PackedScene" uid="uid://c8yvxg3xnq6yw" path="res://tests/SimpleAudioVisualizerTestScene.tscn" id="1_r3j2k"]
 
 [node name="MainScene" type="Node"]
 

--- a/godot_project/Scenes/Radio/RadioTuner.gd
+++ b/godot_project/Scenes/Radio/RadioTuner.gd
@@ -14,7 +14,6 @@ var _current_signal_id = null
 var _signal_strength: float = 0.0
 var _static_intensity: float = 0.5
 var _scan_timer: Timer = null
-var _last_process_time: int = 0
 
 ## References to singletons
 var _game_state = null
@@ -86,6 +85,7 @@ func _create_scan_timer() -> void:
 
 ## Connect UI signals to their handlers
 func _connect_signals() -> void:
+	# Connect UI button signals
 	if _power_button:
 		_power_button.pressed.connect(_on_power_button_pressed)
 	else:
@@ -115,6 +115,13 @@ func _connect_signals() -> void:
 		_tune_up_button.pressed.connect(_on_tune_up_button_pressed)
 	else:
 		$TuneUpButton.pressed.connect(_on_tune_up_button_pressed)
+
+	# Connect GameState signals
+	if _game_state:
+		if _game_state.has_signal("FrequencyChanged"):
+			_game_state.connect("FrequencyChanged", _on_frequency_changed)
+		if _game_state.has_signal("RadioToggled"):
+			_game_state.connect("RadioToggled", _on_radio_toggled)
 
 # Process function called every frame
 func _process(delta):
@@ -323,3 +330,12 @@ func _on_scan_timer_timeout():
 			new_freq = min_frequency
 
 		_game_state.set_frequency(new_freq)
+
+# Signal handlers for GameState signals
+func _on_frequency_changed(_new_frequency):
+	# Update UI when frequency changes
+	_update_ui()
+
+func _on_radio_toggled(_is_on):
+	# Update UI when radio is toggled
+	_update_ui()


### PR DESCRIPTION
This PR fixes two issues:

1. RadioTuner UI Update Issue:
   - Added connections to the GameState's FrequencyChanged and RadioToggled signals
   - Added signal handler methods to update the UI when these signals are emitted
   - This fixes the failing test that was checking if the frequency display updates when the GameState frequency changes

2. C# Build Error:
   - Added the partial keyword to the LogParser class
   - This fixes the build error: 'GD0001: Missing partial modifier on declaration of type SignalLost.LogParser that derives from Godot.GodotObject'