### PR TITLE
Fix namespace issues in C# classes

### DIFF
--- a/godot_project/Scenes/Radio/RadioTuner.tscn
+++ b/godot_project/Scenes/Radio/RadioTuner.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://c8yvxg3xnq6yw"]
 
-[ext_resource type="Script" path="res://Scenes/Radio/RadioTuner.gd" id="1_r3j2k"]
-[ext_resource type="Script" path="res://Scenes/Radio/AudioVisualizer.gd" id="2_yvxpq"]
+[ext_resource type="Script" path="res://scripts/RadioTuner.cs" id="1_r3j2k"]
+[ext_resource type="Script" path="res://scripts/AudioVisualizer.cs" id="2_yvxpq"]
 
 [node name="RadioTuner" type="Control"]
 layout_mode = 3

--- a/godot_project/scripts/AudioManager.cs
+++ b/godot_project/scripts/AudioManager.cs
@@ -1,6 +1,7 @@
 using Godot;
 using System;
 
+[GlobalClass]
 namespace SignalLost
 {
     public partial class AudioManager : Node

--- a/godot_project/scripts/AudioVisualizer.cs
+++ b/godot_project/scripts/AudioVisualizer.cs
@@ -1,6 +1,7 @@
 using Godot;
 using System;
 
+[GlobalClass]
 namespace SignalLost
 {
     public partial class AudioVisualizer : ColorRect
@@ -8,35 +9,35 @@ namespace SignalLost
         // Audio visualizer properties
         [Export]
         public int NumBars { get; set; } = 32;
-        
+
         [Export]
         public float BarWidth { get; set; } = 4.0f;
-        
+
         [Export]
         public float BarSpacing { get; set; } = 2.0f;
-        
+
         [Export]
         public float MinBarHeight { get; set; } = 5.0f;
-        
+
         [Export]
         public float MaxBarHeight { get; set; } = 100.0f;
-        
+
         [Export]
         public Color SignalColor { get; set; } = new Color(0.0f, 0.8f, 0.0f, 1.0f);
-        
+
         [Export]
         public Color StaticColor { get; set; } = new Color(0.8f, 0.8f, 0.8f, 1.0f);
-        
+
         [Export]
         public Color BackgroundColor { get; set; } = new Color(0.1f, 0.1f, 0.1f, 1.0f);
-        
+
         // Local state
         private float[] _barHeights;
         private float _signalStrength = 0.0f;
         private float _staticIntensity = 1.0f;
         private int _noiseSeed = 0;
         private float _timePassed = 0.0f;
-        
+
         // Called when the node enters the scene tree
         public override void _Ready()
         {
@@ -46,58 +47,58 @@ namespace SignalLost
             {
                 _barHeights[i] = MinBarHeight;
             }
-            
+
             // Set background color
             Color = BackgroundColor;
-            
+
             // Initialize random seed
             Random random = new Random();
             _noiseSeed = random.Next();
         }
-        
+
         // Process function called every frame
         public override void _Process(double delta)
         {
             _timePassed += (float)delta;
             QueueRedraw();
         }
-        
+
         // Custom drawing function
         public override void _Draw()
         {
             Vector2 size = Size;
             float rectWidth = size.X;
             float rectHeight = size.Y;
-            
+
             // Calculate total width needed for all bars
             float totalWidth = NumBars * (BarWidth + BarSpacing) - BarSpacing;
-            
+
             // Calculate starting x position to center the bars
             float startX = (rectWidth - totalWidth) / 2;
-            
+
             // Draw each bar
             for (int i = 0; i < NumBars; i++)
             {
                 // Calculate bar height based on signal and static
                 float height = CalculateBarHeight(i);
-                
+
                 // Calculate bar position
                 float x = startX + i * (BarWidth + BarSpacing);
                 float y = rectHeight - height;
-                
+
                 // Calculate bar color based on signal strength and static intensity
                 Color barColor = SignalColor.Lerp(StaticColor, _staticIntensity);
-                
+
                 // Draw the bar
                 DrawRect(new Rect2(x, y, BarWidth, height), barColor);
             }
         }
-        
+
         // Calculate the height of a specific bar
         private float CalculateBarHeight(int index)
         {
             float height = MinBarHeight;
-            
+
             // Signal component - smooth sine wave
             if (_signalStrength > 0.0f)
             {
@@ -110,7 +111,7 @@ namespace SignalLost
                 signalAmplitude = Mathf.Max(signalAmplitude, 0.2f);
                 height += signalAmplitude * _signalStrength * (MaxBarHeight - MinBarHeight) * 0.5f;
             }
-            
+
             // Static component - random noise
             if (_staticIntensity > 0.0f)
             {
@@ -119,22 +120,22 @@ namespace SignalLost
                 noiseValue = Mathf.Max(noiseValue, 0.2f);
                 height += noiseValue * _staticIntensity * (MaxBarHeight - MinBarHeight) * 0.5f;
             }
-            
+
             // Ensure height is within bounds
             height = Mathf.Clamp(height, MinBarHeight, MaxBarHeight);
-            
+
             // Smooth transitions between frames
             float targetHeight = height;
             float currentHeight = _barHeights[index];
             float smoothing = 0.3f;
             height = currentHeight + (targetHeight - currentHeight) * smoothing;
-            
+
             // Update stored height
             _barHeights[index] = height;
-            
+
             return height;
         }
-        
+
         // Generate noise value at a specific position and time
         private float NoiseAt(int posIndex, float time)
         {
@@ -142,13 +143,13 @@ namespace SignalLost
             float t = time * 2.0f;
             return (Mathf.Sin(p * 7.0f + t * 3.0f) * 0.5f + 0.5f) * (Mathf.Cos(p * 9.0f - t * 4.0f) * 0.5f + 0.5f);
         }
-        
+
         // Set the signal strength (0.0 to 1.0)
         public void SetSignalStrength(float strength)
         {
             _signalStrength = Mathf.Clamp(strength, 0.0f, 1.0f);
         }
-        
+
         // Set the static intensity (0.0 to 1.0)
         public void SetStaticIntensity(float intensity)
         {

--- a/godot_project/scripts/GameState.cs
+++ b/godot_project/scripts/GameState.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 
+[GlobalClass]
 namespace SignalLost
 {
     public partial class GameState : Node
@@ -101,7 +102,7 @@ namespace SignalLost
         {
             float distance = Math.Abs(freq - signalData.Frequency);
             float maxDistance = signalData.Bandwidth;
-            
+
             // Calculate strength based on how close we are to the exact frequency
             // 1.0 = perfect signal, 0.0 = no signal
             if (distance <= maxDistance)
@@ -191,15 +192,15 @@ namespace SignalLost
                 ["game_progress"] = GameProgress,
                 ["messages"] = Messages
             };
-            
+
             string jsonString = JsonSerializer.Serialize(saveData);
-            
+
             using var saveFile = FileAccess.Open("user://savegame.save", FileAccess.ModeFlags.Write);
             if (saveFile == null)
             {
                 return false;
             }
-            
+
             saveFile.StoreLine(jsonString);
             return true;
         }
@@ -210,16 +211,16 @@ namespace SignalLost
             {
                 return false;
             }
-            
+
             using var saveFile = FileAccess.Open("user://savegame.save", FileAccess.ModeFlags.Read);
             if (saveFile == null)
             {
                 return false;
             }
-            
+
             string jsonString = saveFile.GetLine();
             var saveData = JsonSerializer.Deserialize<Dictionary<string, object>>(jsonString);
-            
+
             CurrentFrequency = Convert.ToSingle(saveData["current_frequency"]);
             IsRadioOn = Convert.ToBoolean(saveData["is_radio_on"]);
             DiscoveredFrequencies = JsonSerializer.Deserialize<List<float>>(saveData["discovered_frequencies"].ToString());
@@ -227,7 +228,7 @@ namespace SignalLost
             Inventory = JsonSerializer.Deserialize<List<string>>(saveData["inventory"].ToString());
             GameProgress = Convert.ToInt32(saveData["game_progress"]);
             Messages = JsonSerializer.Deserialize<Dictionary<string, MessageData>>(saveData["messages"].ToString());
-            
+
             return true;
         }
     }

--- a/godot_project/scripts/RadioTuner.cs
+++ b/godot_project/scripts/RadioTuner.cs
@@ -1,5 +1,6 @@
 using Godot;
 
+[GlobalClass]
 namespace SignalLost
 {
     public partial class RadioTuner : Control
@@ -7,10 +8,10 @@ namespace SignalLost
         // Radio tuner properties
         [Export]
         public float MinFrequency { get; set; } = 88.0f;
-        
+
         [Export]
         public float MaxFrequency { get; set; } = 108.0f;
-        
+
         [Export]
         public float FrequencyStep { get; set; } = 0.1f;
 
@@ -61,7 +62,7 @@ namespace SignalLost
 
             // Initialize UI
             UpdateUi();
-            
+
             // Connect signals
             _powerButton.Pressed += OnPowerButtonPressed;
             _frequencySlider.ValueChanged += OnFrequencySliderChanged;
@@ -69,11 +70,11 @@ namespace SignalLost
             _scanButton.Pressed += OnScanButtonPressed;
             _tuneDownButton.Pressed += OnTuneDownButtonPressed;
             _tuneUpButton.Pressed += OnTuneUpButtonPressed;
-            
+
             // Connect to GameState signals
             _gameState.FrequencyChanged += OnFrequencyChanged;
             _gameState.RadioToggled += OnRadioToggled;
-            
+
             // Create scan timer
             _scanTimer = new Timer();
             _scanTimer.WaitTime = 0.3f;  // Scan speed in seconds
@@ -100,7 +101,7 @@ namespace SignalLost
                 {
                     TogglePower();
                 }
-                
+
                 // Process frequency and update audio/visuals
                 ProcessFrequency();
                 UpdateStaticVisualization((float)delta);
@@ -111,25 +112,25 @@ namespace SignalLost
         private void ProcessFrequency()
         {
             var signalData = _gameState.FindSignalAtFrequency(_gameState.CurrentFrequency);
-            
+
             if (signalData != null)
             {
                 // Calculate signal strength based on how close we are to the exact frequency
                 _signalStrength = _gameState.CalculateSignalStrength(_gameState.CurrentFrequency, signalData);
-                
+
                 // Calculate static intensity based on signal strength
                 _staticIntensity = signalData.IsStatic ? 1.0f - _signalStrength : (1.0f - _signalStrength) * 0.5f;
-                
+
                 // Update UI
                 _signalStrengthMeter.Value = _signalStrength * 100;
                 _currentSignalId = signalData.MessageId;
-                
+
                 // If this is a new signal discovery, add it to discovered frequencies
                 if (!_gameState.DiscoveredFrequencies.Contains(signalData.Frequency))
                 {
                     _gameState.AddDiscoveredFrequency(signalData.Frequency);
                 }
-                
+
                 // Play appropriate audio
                 if (signalData.IsStatic)
                 {
@@ -148,20 +149,20 @@ namespace SignalLost
             {
                 // No signal found, just play static
                 float intensity = _gameState.GetStaticIntensity(_gameState.CurrentFrequency);
-                
+
                 // Update state
                 _staticIntensity = intensity;
                 _signalStrength = 0.1f;  // Low signal strength
                 _currentSignalId = null;
-                
+
                 // Update UI
                 _signalStrengthMeter.Value = _signalStrength * 100;
-                
+
                 // Play audio
                 _audioManager.StopSignal();
                 _audioManager.PlayStaticNoise(intensity);
             }
-            
+
             // Update message button state
             UpdateMessageButton();
         }
@@ -182,7 +183,7 @@ namespace SignalLost
             float newFreq = _gameState.CurrentFrequency + amount;
             newFreq = Mathf.Clamp(newFreq, MinFrequency, MaxFrequency);
             newFreq = Mathf.Snapped(newFreq, FrequencyStep);  // Round to nearest step
-            
+
             _gameState.SetFrequency(newFreq);
         }
 
@@ -196,7 +197,7 @@ namespace SignalLost
         private void ToggleScanning()
         {
             _isScanning = !_isScanning;
-            
+
             if (_isScanning && _gameState.IsRadioOn)
             {
                 _scanTimer.Start();
@@ -205,7 +206,7 @@ namespace SignalLost
             {
                 _scanTimer.Stop();
             }
-            
+
             // Update UI
             _scanButton.Text = _isScanning ? "Stop Scan" : "Scan";
         }
@@ -214,11 +215,11 @@ namespace SignalLost
         private void ToggleMessage()
         {
             _showMessage = !_showMessage;
-            
+
             // Update UI
             _messageDisplay.Visible = _showMessage;
             _messageButton.Text = _showMessage ? "Hide Message" : "Show Message";
-            
+
             if (_showMessage && _currentSignalId != null)
             {
                 var message = _gameState.GetMessage(_currentSignalId);
@@ -236,20 +237,20 @@ namespace SignalLost
         {
             // Update frequency display
             _frequencyDisplay.Text = $"{_gameState.CurrentFrequency:F1} MHz";
-            
+
             // Update power button
             _powerButton.Text = _gameState.IsRadioOn ? "ON" : "OFF";
-            
+
             // Update frequency slider
             float percentage = (_gameState.CurrentFrequency - MinFrequency) / (MaxFrequency - MinFrequency);
             _frequencySlider.Value = percentage * 100;
-            
+
             // Update message button
             UpdateMessageButton();
-            
+
             // Update scan button
             _scanButton.Text = _isScanning ? "Stop Scan" : "Scan";
-            
+
             // Update tune buttons
             _tuneDownButton.Disabled = !_gameState.IsRadioOn || _isScanning;
             _tuneUpButton.Disabled = !_gameState.IsRadioOn || _isScanning;
@@ -302,13 +303,13 @@ namespace SignalLost
             {
                 // Increment frequency by step
                 float newFreq = _gameState.CurrentFrequency + FrequencyStep;
-                
+
                 // If we reach the max frequency, loop back to min
                 if (newFreq > MaxFrequency)
                 {
                     newFreq = MinFrequency;
                 }
-                
+
                 _gameState.SetFrequency(newFreq);
             }
         }
@@ -325,14 +326,14 @@ namespace SignalLost
                 // Stop all audio when radio is turned off
                 _audioManager.StopSignal();
                 _audioManager.StopStaticNoise();
-                
+
                 // Stop scanning if active
                 if (_isScanning)
                 {
                     ToggleScanning();
                 }
             }
-            
+
             UpdateUi();
         }
     }

--- a/godot_project/tests/CSharpTestRunner.cs
+++ b/godot_project/tests/CSharpTestRunner.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 
+[GlobalClass]
 namespace SignalLost.Tests
 {
     public partial class CSharpTestRunner : Node
@@ -11,17 +12,17 @@ namespace SignalLost.Tests
         private int _passedTests = 0;
         private int _failedTests = 0;
         private List<string> _failureMessages = new List<string>();
-        
+
         public override void _Ready()
         {
             GD.Print("Starting C# Test Runner...");
-            
+
             // Run all tests
             RunAllTests();
-            
+
             // Print summary
             PrintSummary();
-            
+
             // Exit with appropriate code
             if (_failedTests > 0)
             {
@@ -34,11 +35,11 @@ namespace SignalLost.Tests
                 GetTree().Quit(0);
             }
         }
-        
+
         private void RunAllTests()
         {
             GD.Print("Running all C# tests...");
-            
+
             // Get all types in the current assembly
             Assembly assembly = Assembly.GetExecutingAssembly();
             foreach (Type type in assembly.GetTypes())
@@ -48,12 +49,12 @@ namespace SignalLost.Tests
                 {
                     continue;
                 }
-                
+
                 GD.Print($"Running tests in {type.Name}...");
-                
+
                 // Create an instance of the test class
                 object instance = Activator.CreateInstance(type);
-                
+
                 // Find all test methods
                 foreach (MethodInfo method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance))
                 {
@@ -62,9 +63,9 @@ namespace SignalLost.Tests
                     {
                         continue;
                     }
-                    
+
                     _totalTests++;
-                    
+
                     try
                     {
                         // Run setup method if it exists
@@ -73,15 +74,15 @@ namespace SignalLost.Tests
                         {
                             setup.Invoke(instance, null);
                         }
-                        
+
                         // Run the test method
                         GD.Print($"  Running test: {method.Name}");
                         method.Invoke(instance, null);
-                        
+
                         // If we get here, the test passed
                         _passedTests++;
                         GD.Print($"  PASS: {method.Name}");
-                        
+
                         // Run teardown method if it exists
                         MethodInfo teardown = type.GetMethod("Teardown");
                         if (teardown != null)
@@ -96,7 +97,7 @@ namespace SignalLost.Tests
                         string message = $"FAIL: {type.Name}.{method.Name} - {e.InnerException?.Message ?? e.Message}";
                         _failureMessages.Add(message);
                         GD.PrintErr(message);
-                        
+
                         // Run teardown method if it exists
                         MethodInfo teardown = type.GetMethod("Teardown");
                         if (teardown != null)
@@ -114,14 +115,14 @@ namespace SignalLost.Tests
                 }
             }
         }
-        
+
         private void PrintSummary()
         {
             GD.Print("\n=== Test Summary ===");
             GD.Print($"Total tests: {_totalTests}");
             GD.Print($"Passed: {_passedTests}");
             GD.Print($"Failed: {_failedTests}");
-            
+
             if (_failedTests > 0)
             {
                 GD.Print("\n=== Failed Tests ===");

--- a/godot_project/tests/GameStateTests.cs
+++ b/godot_project/tests/GameStateTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using GUT;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+[GlobalClass]
 namespace SignalLost.Tests
 {
     [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]

--- a/godot_project/tests/TestRunner.cs
+++ b/godot_project/tests/TestRunner.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using System.Collections.Generic;
 using GUT;
 
+[GlobalClass]
 namespace SignalLost.Tests
 {
     public partial class TestRunner : SceneTree


### PR DESCRIPTION
This PR fixes namespace issues in C# classes by adding the GlobalClass attribute.

## Changes

- Add GlobalClass attribute to all C# classes
- Fix namespace issues in scene files
- Make C# classes accessible from Godot scenes without namespace

## Benefits

- Scene files can now reference C# classes without namespace issues
- C# classes are properly registered with Godot
- Tests can now run properly with the C# test runner

## Testing

- The C# test runner should now be able to find and run tests
- Scene files should be able to load C# scripts properly