### PR TITLE
Fix error reporting scripts to use environment variables

### DIFF
--- a/godot_project/README.md
+++ b/godot_project/README.md
@@ -47,13 +47,31 @@ The `RadioTuner` scene is the main gameplay element, allowing the player to:
 The project uses a custom testing framework for automated testing. Tests can be run from the terminal using:
 
 ```bash
-./run_custom_tests.sh
+# Linux/Mac
+./run_csharp_tests.sh
+
+# Windows
+run_csharp_tests.bat
 ```
 
-Or for integration tests:
+For custom tests:
 
 ```bash
+# Linux/Mac
+./run_custom_tests.sh
+
+# Windows
+run_custom_tests.bat
+```
+
+For integration tests:
+
+```bash
+# Linux/Mac
 ./run_integration_tests.sh
+
+# Windows
+run_integration_tests.bat
 ```
 
 ## Development
@@ -65,13 +83,51 @@ Or for integration tests:
 
 ## Running the Project
 
-The easiest way to run the project is to use the provided script:
+### Standard Run
+
+The easiest way to run the project is to use the provided scripts:
 
 ```bash
-./run_project.sh
+# Linux/Mac
+./run.sh
+
+# Windows
+run.bat
 ```
 
-This will automatically find the Godot executable and run the project.
+### Run with Error Reporting
+
+To run the project with error reporting enabled:
+
+```bash
+# Linux/Mac
+./run_with_error_report.sh
+
+# Windows
+run_with_error_report.bat
+```
+
+These scripts will run the project and generate an error report in the `logs` directory.
+
+### Setting Up Godot
+
+#### Option 1: Add Godot to PATH
+
+The simplest way to run the project is to add Godot to your system PATH.
+
+#### Option 2: Set GODOT_PATH Environment Variable
+
+You can set the `GODOT_PATH` environment variable to the full path of your Godot executable:
+
+```bash
+# Linux/Mac
+export GODOT_PATH=/path/to/godot
+
+# Windows
+set GODOT_PATH=C:\path\to\Godot_v4.4.1-stable_mono_win64_console.exe
+```
+
+### Using the Godot Editor
 
 Alternatively, you can open the project in the Godot editor:
 
@@ -108,5 +164,26 @@ If you encounter any issues:
 2. Check that all the required assets are in the correct locations
 3. Try running the project from the Godot editor to see any error messages
 4. Check the console output for any error messages
-5. If you see errors about missing icon.png, make sure the file exists in the assets/images directory
-6. If you see errors about missing audio files, you may need to add your own audio files to the assets/audio directory
+5. Run the project with error reporting enabled to generate detailed logs
+6. If you see errors about missing icon.png, make sure the file exists in the assets/images directory
+7. If you see errors about missing audio files, you may need to add your own audio files to the assets/audio directory
+
+## Cleanup
+
+To clean up gitignored files and directories:
+
+```bash
+# Linux/Mac
+./cleanup_gitignored.sh
+
+# Windows
+cleanup_gitignored.bat
+```
+
+This will remove:
+- `.godot` directory
+- `logs` directory
+- `.uid` files
+- `.import` files
+- `.tmp` files
+- `.bak` files

--- a/godot_project/run_with_error_report.bat
+++ b/godot_project/run_with_error_report.bat
@@ -4,12 +4,19 @@ REM This script runs the Godot project and generates an error report
 echo Running Signal Lost Godot project with error reporting...
 
 REM Set the Godot executable path
-set "GODOT_EXECUTABLE=C:\Godot_v4.4.1-stable_mono_win64\Godot_v4.4.1-stable_mono_win64\Godot_v4.4.1-stable_mono_win64_console.exe"
+REM Check if GODOT_PATH environment variable is set
+if defined GODOT_PATH (
+    set "GODOT_EXECUTABLE=%GODOT_PATH%"
+) else (
+    REM Default to godot in PATH
+    set "GODOT_EXECUTABLE=godot"
+)
 
-REM Check if Godot executable exists
-if not exist "%GODOT_EXECUTABLE%" (
-    echo Error: Godot executable not found at %GODOT_EXECUTABLE%
-    echo Please install Godot or update the script with the correct path.
+REM Check if Godot executable exists or is in PATH
+where /q "%GODOT_EXECUTABLE%"
+if %ERRORLEVEL% neq 0 (
+    echo Error: Godot executable not found at %GODOT_EXECUTABLE% or in PATH
+    echo Please install Godot, add it to PATH, or set the GODOT_PATH environment variable.
     exit /b 1
 )
 

--- a/godot_project/run_with_error_report.sh
+++ b/godot_project/run_with_error_report.sh
@@ -3,22 +3,28 @@
 
 echo "Running Signal Lost Godot project with error reporting..."
 
-# Set the Godot executable path based on OS
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    # macOS
-    GODOT_EXECUTABLE="/Applications/Godot.app/Contents/MacOS/Godot"
-elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    # Linux
-    GODOT_EXECUTABLE="godot"
+# Set the Godot executable path
+# Check if GODOT_PATH environment variable is set
+if [ -n "$GODOT_PATH" ]; then
+    GODOT_EXECUTABLE="$GODOT_PATH"
 else
-    # Windows with WSL or Git Bash
-    GODOT_EXECUTABLE="C:/Godot_v4.4.1-stable_mono_win64/Godot_v4.4.1-stable_mono_win64/Godot_v4.4.1-stable_mono_win64_console.exe"
+    # Default based on OS
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # macOS
+        GODOT_EXECUTABLE="/Applications/Godot.app/Contents/MacOS/Godot"
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        # Linux
+        GODOT_EXECUTABLE="godot"
+    else
+        # Windows with WSL or Git Bash
+        GODOT_EXECUTABLE="godot"
+    fi
 fi
 
-# Check if Godot executable exists
-if [ ! -f "$GODOT_EXECUTABLE" ]; then
-    echo "Error: Godot executable not found at $GODOT_EXECUTABLE"
-    echo "Please install Godot or update the script with the correct path."
+# Check if Godot executable exists or is in PATH
+if ! command -v "$GODOT_EXECUTABLE" &> /dev/null; then
+    echo "Error: Godot executable not found at $GODOT_EXECUTABLE or in PATH"
+    echo "Please install Godot, add it to PATH, or set the GODOT_PATH environment variable."
     exit 1
 fi
 


### PR DESCRIPTION
This PR fixes the error reporting scripts to use environment variables instead of hardcoded paths.

## Changes

- Update run_with_error_report.bat to use GODOT_PATH environment variable
- Update run_with_error_report.sh to use GODOT_PATH environment variable
- Remove hardcoded paths to program files
- Update README.md with information about error reporting and environment variables

## Benefits

- More secure: No longer logs program files directory
- More flexible: Users can set their own Godot path
- Better documentation: README now explains how to use the scripts
- Cross-platform: Works on Windows, Linux, and Mac

## Testing

- Tested on Windows with GODOT_PATH environment variable
- Tested on Windows with Godot in PATH