### PR TITLE
Fix duplicate UIDs in scene files

### DIFF
--- a/godot_project/MainScene.tscn
+++ b/godot_project/MainScene.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=6 format=3 uid="uid://c8j6y8o4n8qxv"]
 
 [ext_resource type="PackedScene" uid="uid://c8yvxg3xnq6yw" path="res://scenes/radio/RadioTuner.tscn" id="1_r3j2k"]
-[ext_resource type="PackedScene" uid="uid://c8yvxg3xnq6yw" path="res://scenes/map/MapUI.tscn" id="2_m4p7q"]
+[ext_resource type="PackedScene" uid="uid://b8yvxg3xnq6yw" path="res://scenes/map/MapUI.tscn" id="2_m4p7q"]
 [ext_resource type="Script" path="res://scripts/MainScene.cs" id="3_8j7xp"]
 [ext_resource type="PackedScene" uid="uid://c8yvvs1yvqnxl" path="res://scenes/inventory/InventoryUI.tscn" id="4_ixnqm"]
 [ext_resource type="PackedScene" uid="uid://c8yvvs1yvqnxq" path="res://scenes/quest/QuestUI.tscn" id="5_ixnqn"]

--- a/godot_project/Scenes/map/MapUI.tscn
+++ b/godot_project/Scenes/map/MapUI.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://c8yvxg3xnq6yw"]
+[gd_scene load_steps=2 format=3 uid="uid://b8yvxg3xnq6yw"]
 
 [ext_resource type="Script" path="res://scripts/MapUI.cs" id="1_r3j2k"]
 

--- a/godot_project/tests/ComprehensiveTestRunnerScene.tscn
+++ b/godot_project/tests/ComprehensiveTestRunnerScene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=3 format=3 uid="uid://c8j6y8o4n8qxv"]
+[gd_scene load_steps=3 format=3 uid="uid://h8j6y8o4n8qxv"]
 
 [ext_resource type="Script" path="res://tests/CSharpTestRunner.cs" id="1_0xnvs"]
 [ext_resource type="Script" path="res://tests/TestRunner.cs" id="2_f7g8h"]

--- a/godot_project/tests/FullIntegrationTestScene.tscn
+++ b/godot_project/tests/FullIntegrationTestScene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://c8yvxg3xnq6yw"]
+[gd_scene load_steps=2 format=3 uid="uid://f8yvxg3xnq6yw"]
 
 [ext_resource type="Script" path="res://tests/IntegrationTests.cs" id="1_r3j2k"]
 

--- a/godot_project/tests/GutTestRunner.tscn
+++ b/godot_project/tests/GutTestRunner.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://c8yvxg3xnq6yw"]
+[gd_scene load_steps=2 format=3 uid="uid://g8yvxg3xnq6yw"]
 
 [ext_resource type="Script" path="res://addons/gut/addons/gut/gut.gd" id="1_r3j2k"]
 

--- a/godot_project/tests/SimpleAudioVisualizerTestScene.tscn
+++ b/godot_project/tests/SimpleAudioVisualizerTestScene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://c8yvxg3xnq6yw"]
+[gd_scene load_steps=2 format=3 uid="uid://d8yvxg3xnq6yw"]
 
 [ext_resource type="Script" path="res://tests/SimpleTest.cs" id="1_r3j2k"]
 

--- a/godot_project/tests/audio_visualizer/SimpleAudioVisualizerTestScene.tscn
+++ b/godot_project/tests/audio_visualizer/SimpleAudioVisualizerTestScene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3 uid="uid://c8yvxg3xnq6yw"]
+[gd_scene load_steps=2 format=3 uid="uid://e8yvxg3xnq6yw"]
 
 [ext_resource type="Script" path="res://tests/SimpleTest.cs" id="1_r3j2k"]
 


### PR DESCRIPTION
This PR fixes duplicate UIDs in scene files that were causing warnings when loading the project. Specifically:

- Fixed duplicate UIDs between RadioTuner.tscn and MapUI.tscn
- Fixed duplicate UIDs in test scenes

This should resolve the warnings when loading the project and allow the game to run properly.