### PR TITLE
Add pixel-based radio interface with visualization

### DIFF
--- a/godot_project/Scenes/Radio/PixelRadioInterface.tscn
+++ b/godot_project/Scenes/Radio/PixelRadioInterface.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/PixelRadioInterface.cs" id="1_pixel"]
+
+[node name="PixelRadioInterface" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_pixel")

--- a/godot_project/Scenes/test/PixelRadioTest.tscn
+++ b/godot_project/Scenes/test/PixelRadioTest.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/RadioTuner.cs" id="1_radio"]
+[ext_resource type="Script" path="res://scripts/PixelRadioInterface.cs" id="2_pixel"]
+[ext_resource type="Script" path="res://scripts/PixelRadioVisualizer.cs" id="3_visualizer"]
+[ext_resource type="Script" path="res://scripts/ScreenshotTaker.cs" id="4_screenshot"]
+
+[node name="PixelRadioTest" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="RadioTuner" type="Node" parent="."]
+script = ExtResource("1_radio")
+
+[node name="PixelRadioInterface" type="Control" parent="RadioTuner"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("2_pixel")
+
+[node name="PixelRadioVisualizer" type="Node" parent="."]
+script = ExtResource("3_visualizer")
+
+[node name="ScreenshotTaker" type="Node" parent="."]
+script = ExtResource("4_screenshot")

--- a/godot_project/scripts/PixelRadioVisualizer.cs
+++ b/godot_project/scripts/PixelRadioVisualizer.cs
@@ -1,0 +1,44 @@
+using Godot;
+using System;
+using System.Text;
+
+namespace SignalLost
+{
+    [GlobalClass]
+    public partial class PixelRadioVisualizer : Node
+    {
+        // Called when the node enters the scene tree
+        public override void _Ready()
+        {
+            GD.Print("PixelRadioVisualizer ready!");
+            
+            // Find the PixelRadioInterface
+            var radioInterface = GetParent().GetNode<PixelRadioInterface>("RadioTuner/PixelRadioInterface");
+            
+            if (radioInterface != null)
+            {
+                // Visualize the radio interface
+                UIVisualizer.VisualizeUI(radioInterface);
+            }
+            else
+            {
+                GD.PrintErr("PixelRadioVisualizer: Could not find PixelRadioInterface!");
+            }
+        }
+        
+        // Called every frame
+        public override void _Process(double delta)
+        {
+            // Periodically visualize the radio interface
+            if (Time.GetTicksMsec() % 5000 < 100) // Every 5 seconds
+            {
+                var radioInterface = GetParent().GetNode<PixelRadioInterface>("RadioTuner/PixelRadioInterface");
+                
+                if (radioInterface != null)
+                {
+                    UIVisualizer.VisualizeUI(radioInterface);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a pixel-based radio interface with visualization capabilities. It includes:

1. A PixelRadioInterface scene and script for the radio UI
2. A PixelRadioVisualizer script for debugging the UI
3. A test scene to demonstrate the pixel-based radio interface

These changes build on the UI visualization system from PR #98 to provide a more cohesive and maintainable radio interface for the game.