### PR TITLE
Update .gitignore to exclude backup files and screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ builds/
 
 # Godot-specific backup files
 *.bak
+*.bak2
+*.pixel
 
 # Godot-specific user settings
 .godot/editor_settings-*.tres
@@ -55,3 +57,6 @@ temp_gut/
 
 # Generated files
 godot_project/tools/scene_analysis.md
+
+# Screenshots
+screenshot*.png


### PR DESCRIPTION
This PR updates the .gitignore file to exclude:

1. Additional backup file formats (*.bak2, *.pixel)
2. Screenshot files (screenshot*.png)

These changes will prevent unnecessary files from being tracked in the repository, keeping it clean and focused on essential code and assets.

The PR also addresses the remaining unstaged files in the project, which were backup files and screenshots that don't need to be included in the repository.