### PR TITLE
Add signal strength indicators for radio interface

### DIFF
--- a/godot_project/Scenes/Radio/SignalStrengthTest.tscn
+++ b/godot_project/Scenes/Radio/SignalStrengthTest.tscn
@@ -1,0 +1,91 @@
+[gd_scene load_steps=4 format=3 uid="uid://c8yvxg3xnq6yw"]
+
+[ext_resource type="Script" path="res://scripts/SignalStrengthTest.cs" id="1_test"]
+[ext_resource type="Script" path="res://scripts/SignalStrengthIndicator.cs" id="2_signal"]
+[ext_resource type="Script" path="res://scripts/PixelSignalStrengthIndicator.cs" id="3_pixel"]
+
+[node name="SignalStrengthTest" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_test")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -200.0
+offset_top = -150.0
+offset_right = 200.0
+offset_bottom = 150.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 20
+
+[node name="Title" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Signal Strength Indicators"
+horizontal_alignment = 1
+
+[node name="StandardIndicator" type="Control" parent="VBoxContainer"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+script = ExtResource("2_signal")
+
+[node name="IndicatorLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Standard Signal Strength Indicator"
+horizontal_alignment = 1
+
+[node name="PixelIndicator" type="Control" parent="VBoxContainer"]
+custom_minimum_size = Vector2(0, 100)
+layout_mode = 2
+script = ExtResource("3_pixel")
+
+[node name="PixelLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Pixel Art Signal Strength Indicator"
+horizontal_alignment = 1
+
+[node name="Slider" type="HSlider" parent="VBoxContainer"]
+layout_mode = 2
+value = 50.0
+
+[node name="SliderLabel" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+text = "Adjust Signal Strength: 50%"
+horizontal_alignment = 1
+
+[node name="TestButtons" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+alignment = 1
+
+[node name="NoSignalButton" type="Button" parent="VBoxContainer/TestButtons"]
+layout_mode = 2
+text = "No Signal"
+
+[node name="WeakButton" type="Button" parent="VBoxContainer/TestButtons"]
+layout_mode = 2
+text = "Weak"
+
+[node name="MediumButton" type="Button" parent="VBoxContainer/TestButtons"]
+layout_mode = 2
+text = "Medium"
+
+[node name="StrongButton" type="Button" parent="VBoxContainer/TestButtons"]
+layout_mode = 2
+text = "Strong"
+
+[node name="PerfectButton" type="Button" parent="VBoxContainer/TestButtons"]
+layout_mode = 2
+text = "Perfect"
+
+[node name="ScreenshotButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Take Screenshot"

--- a/godot_project/scripts/PixelSignalStrengthIndicator.cs
+++ b/godot_project/scripts/PixelSignalStrengthIndicator.cs
@@ -1,0 +1,200 @@
+using Godot;
+using System;
+
+namespace SignalLost
+{
+    [GlobalClass]
+    public partial class PixelSignalStrengthIndicator : Control
+    {
+        // Signal strength indicator properties
+        [Export]
+        public Color BackgroundColor { get; set; } = new Color(0.1f, 0.1f, 0.1f, 1.0f);
+        
+        [Export]
+        public Color BorderColor { get; set; } = new Color(0.3f, 0.3f, 0.3f, 1.0f);
+        
+        [Export]
+        public Color SignalColor { get; set; } = new Color(0.0f, 0.8f, 0.0f, 1.0f);
+        
+        [Export]
+        public int PixelSize { get; set; } = 4;
+        
+        [Export]
+        public bool ShowText { get; set; } = true;
+        
+        // Signal strength value (0.0 to 1.0)
+        private float _signalStrength = 0.0f;
+        
+        // Grid dimensions for the pixel art
+        private const int GRID_WIDTH = 16;
+        private const int GRID_HEIGHT = 16;
+        
+        // Called when the node enters the scene tree
+        public override void _Ready()
+        {
+            GD.Print("PixelSignalStrengthIndicator ready!");
+        }
+        
+        // Set the signal strength (0.0 to 1.0)
+        public void SetSignalStrength(float strength)
+        {
+            _signalStrength = Mathf.Clamp(strength, 0.0f, 1.0f);
+            QueueRedraw();
+        }
+        
+        // Get the current signal strength
+        public float GetSignalStrength()
+        {
+            return _signalStrength;
+        }
+        
+        // Custom drawing function
+        public override void _Draw()
+        {
+            // Calculate dimensions
+            float width = GRID_WIDTH * PixelSize;
+            float height = GRID_HEIGHT * PixelSize;
+            
+            // Calculate offset to center the grid in the control
+            float offsetX = (Size.X - width) / 2;
+            float offsetY = (Size.Y - height) / 2;
+            
+            // Draw background
+            DrawRect(new Rect2(0, 0, Size.X, Size.Y), BackgroundColor);
+            
+            // Draw the pixel art signal strength indicator
+            DrawSignalStrengthIcon(offsetX, offsetY);
+            
+            // Draw text if enabled
+            if (ShowText)
+            {
+                string strengthText = $"{_signalStrength * 100:F0}%";
+                Vector2 textSize = ThemeDB.FallbackFont.GetStringSize(strengthText, fontSize: 16);
+                Vector2 textPosition = new Vector2(Size.X / 2 - textSize.X / 2, height + offsetY + 20);
+                
+                DrawString(ThemeDB.FallbackFont, textPosition, strengthText, HorizontalAlignment.Center, -1, 16, SignalColor);
+            }
+        }
+        
+        // Draw the pixel art signal strength icon
+        private void DrawSignalStrengthIcon(float offsetX, float offsetY)
+        {
+            // Define the signal strength icon as a grid of pixels
+            // 0 = empty, 1 = always filled, 2-5 = filled based on signal strength
+            int[,] iconGrid = new int[GRID_WIDTH, GRID_HEIGHT]
+            {
+                {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0},
+                {0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0},
+                {0,0,0,0,0,0,1,1,1,1,0,0,0,0,0,0},
+                {0,0,0,0,0,1,1,1,1,1,1,0,0,0,0,0},
+                {0,0,0,0,1,1,1,1,1,1,1,1,0,0,0,0},
+                {0,0,0,1,1,1,1,1,1,1,1,1,1,0,0,0},
+                {0,0,1,1,1,1,1,1,1,1,1,1,1,1,0,0},
+                {0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0},
+                {0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0},
+                {0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0},
+                {0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0},
+                {0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0},
+                {0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0},
+                {0,0,0,0,0,0,5,5,5,5,0,0,0,0,0,0},
+                {0,0,0,0,0,4,4,4,4,4,4,0,0,0,0,0},
+                {0,0,0,0,3,3,3,3,3,3,3,3,0,0,0,0}
+            };
+            
+            // Calculate signal strength thresholds
+            float threshold2 = 0.25f;
+            float threshold3 = 0.5f;
+            float threshold4 = 0.75f;
+            float threshold5 = 1.0f;
+            
+            // Draw each pixel
+            for (int x = 0; x < GRID_WIDTH; x++)
+            {
+                for (int y = 0; y < GRID_HEIGHT; y++)
+                {
+                    int pixelType = iconGrid[y, x];
+                    
+                    // Determine if this pixel should be drawn
+                    bool drawPixel = false;
+                    
+                    switch (pixelType)
+                    {
+                        case 1: // Always filled
+                            drawPixel = true;
+                            break;
+                        case 2: // Filled if signal strength >= 25%
+                            drawPixel = _signalStrength >= threshold2;
+                            break;
+                        case 3: // Filled if signal strength >= 50%
+                            drawPixel = _signalStrength >= threshold3;
+                            break;
+                        case 4: // Filled if signal strength >= 75%
+                            drawPixel = _signalStrength >= threshold4;
+                            break;
+                        case 5: // Filled if signal strength = 100%
+                            drawPixel = _signalStrength >= threshold5;
+                            break;
+                    }
+                    
+                    // Draw the pixel if needed
+                    if (drawPixel)
+                    {
+                        float pixelX = offsetX + x * PixelSize;
+                        float pixelY = offsetY + y * PixelSize;
+                        
+                        // Calculate color based on signal strength
+                        Color pixelColor = SignalColor;
+                        
+                        // For signal bars, adjust color based on level
+                        if (pixelType >= 2 && pixelType <= 5)
+                        {
+                            float intensity = Mathf.Min(1.0f, _signalStrength * 1.2f);
+                            pixelColor.A = intensity;
+                        }
+                        
+                        DrawRect(new Rect2(pixelX, pixelY, PixelSize, PixelSize), pixelColor);
+                    }
+                }
+            }
+            
+            // Draw signal waves based on signal strength
+            if (_signalStrength > 0.1f)
+            {
+                DrawSignalWaves(offsetX, offsetY);
+            }
+        }
+        
+        // Draw animated signal waves
+        private void DrawSignalWaves(float offsetX, float offsetY)
+        {
+            // Calculate wave parameters based on signal strength
+            float maxRadius = GRID_WIDTH * PixelSize * 0.8f;
+            int numWaves = Mathf.FloorToInt(_signalStrength * 3) + 1;
+            
+            // Get current time for animation
+            float time = (float)Time.GetTicksMsec() / 1000.0f;
+            
+            // Calculate center of the antenna
+            float centerX = offsetX + GRID_WIDTH * PixelSize / 2;
+            float centerY = offsetY + 4 * PixelSize;
+            
+            // Draw each wave
+            for (int i = 0; i < numWaves; i++)
+            {
+                // Calculate wave radius based on time
+                float phase = (time * 2.0f + i * 0.33f) % 1.0f;
+                float radius = phase * maxRadius;
+                
+                // Calculate color based on phase
+                Color waveColor = SignalColor;
+                waveColor.A = (1.0f - phase) * _signalStrength;
+                
+                // Draw the wave as a circle
+                if (waveColor.A > 0.05f)
+                {
+                    DrawArc(new Vector2(centerX, centerY), radius, 0, Mathf.Pi, 16, waveColor, 2.0f * PixelSize / 4.0f);
+                }
+            }
+        }
+    }
+}

--- a/godot_project/scripts/SignalStrengthIndicator.cs
+++ b/godot_project/scripts/SignalStrengthIndicator.cs
@@ -1,0 +1,128 @@
+using Godot;
+using System;
+
+namespace SignalLost
+{
+    [GlobalClass]
+    public partial class SignalStrengthIndicator : Control
+    {
+        // Signal strength indicator properties
+        [Export]
+        public Color BackgroundColor { get; set; } = new Color(0.1f, 0.1f, 0.1f, 1.0f);
+        
+        [Export]
+        public Color BorderColor { get; set; } = new Color(0.3f, 0.3f, 0.3f, 1.0f);
+        
+        [Export]
+        public Color WeakSignalColor { get; set; } = new Color(0.8f, 0.2f, 0.2f, 1.0f);
+        
+        [Export]
+        public Color MediumSignalColor { get; set; } = new Color(0.8f, 0.8f, 0.2f, 1.0f);
+        
+        [Export]
+        public Color StrongSignalColor { get; set; } = new Color(0.2f, 0.8f, 0.2f, 1.0f);
+        
+        [Export]
+        public int NumBars { get; set; } = 5;
+        
+        [Export]
+        public float BarWidth { get; set; } = 6.0f;
+        
+        [Export]
+        public float BarSpacing { get; set; } = 2.0f;
+        
+        [Export]
+        public float BarHeight { get; set; } = 20.0f;
+        
+        [Export]
+        public float BorderWidth { get; set; } = 2.0f;
+        
+        [Export]
+        public bool ShowPercentage { get; set; } = true;
+        
+        // Signal strength value (0.0 to 1.0)
+        private float _signalStrength = 0.0f;
+        
+        // Called when the node enters the scene tree
+        public override void _Ready()
+        {
+            GD.Print("SignalStrengthIndicator ready!");
+        }
+        
+        // Set the signal strength (0.0 to 1.0)
+        public void SetSignalStrength(float strength)
+        {
+            _signalStrength = Mathf.Clamp(strength, 0.0f, 1.0f);
+            QueueRedraw();
+        }
+        
+        // Get the current signal strength
+        public float GetSignalStrength()
+        {
+            return _signalStrength;
+        }
+        
+        // Custom drawing function
+        public override void _Draw()
+        {
+            // Calculate dimensions
+            float totalWidth = NumBars * BarWidth + (NumBars - 1) * BarSpacing + BorderWidth * 2;
+            float totalHeight = BarHeight + BorderWidth * 2;
+            
+            // Draw background and border
+            DrawRect(new Rect2(0, 0, totalWidth, totalHeight), BorderColor);
+            DrawRect(new Rect2(BorderWidth, BorderWidth, totalWidth - BorderWidth * 2, totalHeight - BorderWidth * 2), BackgroundColor);
+            
+            // Calculate how many bars to fill based on signal strength
+            int filledBars = Mathf.FloorToInt(_signalStrength * NumBars);
+            
+            // Draw the bars
+            for (int i = 0; i < NumBars; i++)
+            {
+                float x = BorderWidth + i * (BarWidth + BarSpacing);
+                float y = BorderWidth;
+                
+                // Determine bar color based on position and fill state
+                Color barColor;
+                
+                if (i < filledBars)
+                {
+                    // This bar is filled - determine color based on position
+                    float barPosition = (float)i / NumBars;
+                    
+                    if (barPosition < 0.33f)
+                        barColor = WeakSignalColor;
+                    else if (barPosition < 0.66f)
+                        barColor = MediumSignalColor;
+                    else
+                        barColor = StrongSignalColor;
+                }
+                else
+                {
+                    // This bar is not filled - use a darker version of what it would be
+                    float barPosition = (float)i / NumBars;
+                    
+                    if (barPosition < 0.33f)
+                        barColor = new Color(WeakSignalColor.R * 0.3f, WeakSignalColor.G * 0.3f, WeakSignalColor.B * 0.3f, 1.0f);
+                    else if (barPosition < 0.66f)
+                        barColor = new Color(MediumSignalColor.R * 0.3f, MediumSignalColor.G * 0.3f, MediumSignalColor.B * 0.3f, 1.0f);
+                    else
+                        barColor = new Color(StrongSignalColor.R * 0.3f, StrongSignalColor.G * 0.3f, StrongSignalColor.B * 0.3f, 1.0f);
+                }
+                
+                // Draw the bar
+                DrawRect(new Rect2(x, y, BarWidth, BarHeight), barColor);
+            }
+            
+            // Draw percentage text if enabled
+            if (ShowPercentage)
+            {
+                string percentText = $"{_signalStrength * 100:F0}%";
+                Vector2 textSize = ThemeDB.FallbackFont.GetStringSize(percentText, fontSize: 16);
+                Vector2 textPosition = new Vector2(totalWidth + 10, totalHeight / 2 - textSize.Y / 2);
+                
+                DrawString(ThemeDB.FallbackFont, textPosition, percentText, HorizontalAlignment.Left, -1, 16, new Color(0.8f, 0.8f, 0.8f, 1.0f));
+            }
+        }
+    }
+}

--- a/godot_project/scripts/SignalStrengthTest.cs
+++ b/godot_project/scripts/SignalStrengthTest.cs
@@ -1,0 +1,90 @@
+using Godot;
+using System;
+
+namespace SignalLost
+{
+    public partial class SignalStrengthTest : Control
+    {
+        // References to UI elements
+        private SignalStrengthIndicator _standardIndicator;
+        private PixelSignalStrengthIndicator _pixelIndicator;
+        private HSlider _slider;
+        private Label _sliderLabel;
+        private Button _noSignalButton;
+        private Button _weakButton;
+        private Button _mediumButton;
+        private Button _strongButton;
+        private Button _perfectButton;
+        private Button _screenshotButton;
+
+        // Called when the node enters the scene tree
+        public override void _Ready()
+        {
+            // Get references to UI elements
+            _standardIndicator = GetNode<SignalStrengthIndicator>("VBoxContainer/StandardIndicator");
+            _pixelIndicator = GetNode<PixelSignalStrengthIndicator>("VBoxContainer/PixelIndicator");
+            _slider = GetNode<HSlider>("VBoxContainer/Slider");
+            _sliderLabel = GetNode<Label>("VBoxContainer/SliderLabel");
+            _noSignalButton = GetNode<Button>("VBoxContainer/TestButtons/NoSignalButton");
+            _weakButton = GetNode<Button>("VBoxContainer/TestButtons/WeakButton");
+            _mediumButton = GetNode<Button>("VBoxContainer/TestButtons/MediumButton");
+            _strongButton = GetNode<Button>("VBoxContainer/TestButtons/StrongButton");
+            _perfectButton = GetNode<Button>("VBoxContainer/TestButtons/PerfectButton");
+
+            // Connect signals
+            _slider.ValueChanged += OnSliderValueChanged;
+            _noSignalButton.Pressed += () => SetSignalStrength(0.0f);
+            _weakButton.Pressed += () => SetSignalStrength(0.25f);
+            _mediumButton.Pressed += () => SetSignalStrength(0.5f);
+            _strongButton.Pressed += () => SetSignalStrength(0.75f);
+            _perfectButton.Pressed += () => SetSignalStrength(1.0f);
+
+            // Set initial signal strength
+            SetSignalStrength(_slider.Value / 100.0f);
+
+            GD.Print("SignalStrengthTest ready!");
+        }
+
+        // Called when the slider value changes
+        private void OnSliderValueChanged(double value)
+        {
+            float signalStrength = (float)value / 100.0f;
+            SetSignalStrength(signalStrength);
+        }
+
+        // Set the signal strength for all indicators
+        private void SetSignalStrength(float strength)
+        {
+            // Update slider if needed
+            if (Math.Abs(_slider.Value - strength * 100.0f) > 0.01f)
+            {
+                _slider.Value = strength * 100.0f;
+            }
+
+            // Update label
+            _sliderLabel.Text = $"Adjust Signal Strength: {strength * 100:F0}%";
+
+            // Update indicators
+            _standardIndicator.SetSignalStrength(strength);
+            _pixelIndicator.SetSignalStrength(strength);
+
+            GD.Print($"Signal strength set to {strength:F2}");
+        }
+
+        // Take a screenshot after a delay
+        public void TakeScreenshot(float delay = 1.0f)
+        {
+            var timer = new Timer();
+            AddChild(timer);
+            timer.WaitTime = delay;
+            timer.OneShot = true;
+            timer.Timeout += () => {
+                var image = GetViewport().GetTexture().GetImage();
+                image.SavePng("user://signal_strength_test.png");
+                GD.Print("Screenshot saved to user://signal_strength_test.png");
+                timer.QueueFree();
+            };
+            timer.Start();
+        }
+    }
+}

--- a/godot_project/scripts/SimpleRadioTest.cs
+++ b/godot_project/scripts/SimpleRadioTest.cs
@@ -1,0 +1,495 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+
+namespace SignalLost
+{
+    [GlobalClass]
+    public partial class SimpleRadioTest : Control
+    {
+        // Pixel art settings
+        private const int PIXEL_SIZE = 4; // Size of each "pixel" in our pixel art
+        private const int GRID_WIDTH = 160; // Width in virtual pixels
+        private const int GRID_HEIGHT = 120; // Height in virtual pixels
+
+        // Color palette (retro-inspired)
+        private readonly Color[] _palette = new Color[] {
+            new Color(0.0f, 0.0f, 0.0f),       // Black
+            new Color(0.33f, 0.2f, 0.53f),      // Dark Purple
+            new Color(0.2f, 0.4f, 0.6f),        // Navy Blue
+            new Color(0.26f, 0.53f, 0.96f),     // Bright Blue
+            new Color(0.6f, 0.73f, 1.0f),       // Light Blue
+            new Color(0.93f, 0.94f, 0.9f),      // Off White
+            new Color(0.9f, 0.4f, 0.4f),        // Red
+            new Color(0.4f, 0.73f, 0.4f),       // Green
+            new Color(0.93f, 0.9f, 0.55f)       // Yellow
+        };
+
+        // Noise texture for static effect
+        private List<List<int>> _noiseGrid;
+        private float _noiseTimer = 0.0f;
+        // Radio properties
+        private float _minFrequency = 88.0f;
+        private float _maxFrequency = 108.0f;
+        private float _currentFrequency = 98.0f;
+        private bool _isPowerOn = false;
+        private bool _isScanning = false;
+        private float _signalStrength = 0.0f;
+
+
+
+        // Dragging state
+        private bool _isDraggingSlider = false;
+
+        // Called when the node enters the scene tree
+        public override void _Ready()
+        {
+            GD.Print("SimpleRadioTest ready!");
+
+            // Initialize noise grid for static effect
+            InitializeNoiseGrid();
+        }
+
+        // Initialize the noise grid for static visualization
+        private void InitializeNoiseGrid()
+        {
+            _noiseGrid = new List<List<int>>();
+            Random random = new Random();
+
+            // Create a 2D grid of random noise values
+            for (int y = 0; y < GRID_HEIGHT; y++)
+            {
+                List<int> row = new List<int>();
+                for (int x = 0; x < GRID_WIDTH; x++)
+                {
+                    row.Add(random.Next(0, _palette.Length));
+                }
+                _noiseGrid.Add(row);
+            }
+        }
+
+        // Update the noise grid for animation
+        private void UpdateNoiseGrid(float delta)
+        {
+            if (_noiseGrid == null) return;
+
+            _noiseTimer += delta;
+
+            // Update noise every 0.1 seconds for animation
+            if (_noiseTimer >= 0.1f)
+            {
+                _noiseTimer = 0;
+
+                Random random = new Random();
+
+                // Update about 20% of the pixels each frame for a dynamic effect
+                int pixelsToUpdate = (GRID_WIDTH * GRID_HEIGHT) / 5;
+
+                for (int i = 0; i < pixelsToUpdate; i++)
+                {
+                    int x = random.Next(0, GRID_WIDTH);
+                    int y = random.Next(0, GRID_HEIGHT);
+
+                    // More likely to be dark colors for static
+                    int colorIndex = random.Next(0, 5); // Limit to first 5 colors in palette
+                    _noiseGrid[y][x] = colorIndex;
+                }
+            }
+        }
+
+
+
+        // Process function called every frame
+        public override void _Process(double delta)
+        {
+            float deltaF = (float)delta;
+
+            // Update noise grid for static effect
+            UpdateNoiseGrid(deltaF);
+
+            // If scanning, update frequency
+            if (_isPowerOn && _isScanning)
+            {
+                _currentFrequency += 0.1f;
+                if (_currentFrequency > _maxFrequency)
+                    _currentFrequency = _minFrequency;
+
+                // Generate random signal strength
+                _signalStrength = (float)GD.RandRange(0.0, 1.0);
+            }
+
+            // Simulate signal strength fluctuations for realism
+            if (_isPowerOn && _signalStrength > 0)
+            {
+                // Add some random fluctuation to signal strength
+                float fluctuation = (float)GD.RandRange(-0.05, 0.05);
+                _signalStrength = Mathf.Clamp(_signalStrength + fluctuation, 0.0f, 1.0f);
+            }
+
+            // Redraw the UI
+            QueueRedraw();
+        }
+
+        // Custom drawing function
+        public override void _Draw()
+        {
+            // Calculate the scale to fit our pixel grid to the actual screen size
+            Vector2 size = Size;
+            float scaleX = size.X / (GRID_WIDTH * PIXEL_SIZE);
+            float scaleY = size.Y / (GRID_HEIGHT * PIXEL_SIZE);
+            float scale = Mathf.Min(scaleX, scaleY);
+
+            // Center the pixel grid on screen
+            float offsetX = (size.X - (GRID_WIDTH * PIXEL_SIZE * scale)) / 2;
+            float offsetY = (size.Y - (GRID_HEIGHT * PIXEL_SIZE * scale)) / 2;
+
+            // Draw background (dark color)
+            DrawRect(new Rect2(0, 0, size.X, size.Y), _palette[0]);
+
+            // Draw pixel grid border
+            DrawPixelRect(0, 0, GRID_WIDTH, GRID_HEIGHT, 1, offsetX, offsetY, scale);
+
+            // Draw radio background (dark blue)
+            DrawPixelRect(2, 2, GRID_WIDTH - 4, GRID_HEIGHT - 4, 2, offsetX, offsetY, scale);
+
+            // Draw display area
+            int displayX = 10;
+            int displayY = 10;
+            int displayWidth = GRID_WIDTH - 20;
+            int displayHeight = 20;
+
+            // Display background
+            DrawPixelRect(displayX, displayY, displayWidth, displayHeight, _isPowerOn ? 1 : 0, offsetX, offsetY, scale);
+
+            // Draw frequency text if power is on
+            if (_isPowerOn)
+            {
+                // Draw frequency as pixel text
+                string freqText = $"{_currentFrequency:F1}";
+                DrawPixelText(freqText, displayX + 5, displayY + 6, 5, offsetX, offsetY, scale);
+
+                // Draw MHz label
+                DrawPixelText("MHz", displayX + displayWidth - 25, displayY + 6, 5, offsetX, offsetY, scale);
+
+                // Draw static visualization in the display if signal is weak
+                if (_signalStrength < 0.7f)
+                {
+                    // Draw static noise in the display area
+                    DrawStaticNoise(displayX + 2, displayY + 2, displayWidth - 4, displayHeight - 4,
+                                    1.0f - _signalStrength, offsetX, offsetY, scale);
+                }
+            }
+
+            // Draw buttons
+            int buttonY = GRID_HEIGHT - 30;
+            int buttonHeight = 15;
+
+            // Power button
+            DrawPixelButton(10, buttonY, 30, buttonHeight, _isPowerOn ? "ON" : "OFF", _isPowerOn ? 6 : 2, offsetX, offsetY, scale);
+
+            // Scan button
+            DrawPixelButton(45, buttonY, 30, buttonHeight, _isScanning ? "STOP" : "SCAN",
+                           (_isScanning && _isPowerOn) ? 7 : 2, offsetX, offsetY, scale);
+
+            // Tune buttons
+            DrawPixelButton(GRID_WIDTH - 75, buttonY, 20, buttonHeight, "<", 2, offsetX, offsetY, scale);
+            DrawPixelButton(GRID_WIDTH - 30, buttonY, 20, buttonHeight, ">", 2, offsetX, offsetY, scale);
+
+            // Draw frequency slider
+            int sliderY = GRID_HEIGHT / 2;
+            int sliderHeight = 8;
+            DrawPixelRect(10, sliderY, GRID_WIDTH - 20, sliderHeight, 1, offsetX, offsetY, scale);
+
+            // Draw slider handle
+            if (_isPowerOn)
+            {
+                float frequencyRange = _maxFrequency - _minFrequency;
+                float frequencyPercentage = (_currentFrequency - _minFrequency) / frequencyRange;
+                int handleX = 10 + (int)(frequencyPercentage * (GRID_WIDTH - 20 - 6));
+
+                DrawPixelRect(handleX, sliderY - 2, 6, sliderHeight + 4, 3, offsetX, offsetY, scale);
+            }
+
+            // Draw signal strength meter
+            int meterY = sliderY + 20;
+            int meterHeight = 8;
+            DrawPixelRect(10, meterY, GRID_WIDTH - 20, meterHeight, 1, offsetX, offsetY, scale);
+
+            // Draw signal meter fill
+            if (_isPowerOn)
+            {
+                int fillWidth = (int)((GRID_WIDTH - 20) * _signalStrength);
+                DrawPixelRect(10, meterY, fillWidth, meterHeight, 7, offsetX, offsetY, scale);
+            }
+
+            // Draw signal visualization
+            if (_isPowerOn)
+            {
+                int vizY = meterY + meterHeight + 10;
+                int vizHeight = 20;
+
+                // Background for visualization
+                DrawPixelRect(10, vizY, GRID_WIDTH - 20, vizHeight, 1, offsetX, offsetY, scale);
+
+                // Draw static noise based on signal strength
+                DrawStaticNoise(10, vizY, GRID_WIDTH - 20, vizHeight, 1.0f - _signalStrength, offsetX, offsetY, scale);
+
+                // Draw signal wave if we have good reception
+                if (_signalStrength > 0.3f)
+                {
+                    DrawSignalWave(10, vizY, GRID_WIDTH - 20, vizHeight, _signalStrength, offsetX, offsetY, scale);
+                }
+            }
+        }
+
+        // Helper method to draw a pixel rectangle
+        private void DrawPixelRect(int x, int y, int width, int height, int colorIndex, float offsetX, float offsetY, float scale)
+        {
+            Color color = _palette[colorIndex];
+            DrawRect(
+                new Rect2(
+                    offsetX + x * PIXEL_SIZE * scale,
+                    offsetY + y * PIXEL_SIZE * scale,
+                    width * PIXEL_SIZE * scale,
+                    height * PIXEL_SIZE * scale
+                ),
+                color
+            );
+        }
+
+        // Helper method to draw a pixel button
+        private void DrawPixelButton(int x, int y, int width, int height, string text, int colorIndex, float offsetX, float offsetY, float scale)
+        {
+            // Button background
+            DrawPixelRect(x, y, width, height, colorIndex, offsetX, offsetY, scale);
+
+            // Button border
+            DrawPixelRect(x, y, width, 1, 0, offsetX, offsetY, scale); // Top
+            DrawPixelRect(x, y, 1, height, 0, offsetX, offsetY, scale); // Left
+            DrawPixelRect(x, y + height - 1, width, 1, 0, offsetX, offsetY, scale); // Bottom
+            DrawPixelRect(x + width - 1, y, 1, height, 0, offsetX, offsetY, scale); // Right
+
+            // Button text
+            DrawPixelText(text, x + 3, y + 4, 5, offsetX, offsetY, scale);
+        }
+
+        // Helper method to draw pixel text
+        private void DrawPixelText(string text, int x, int y, int colorIndex, float offsetX, float offsetY, float scale)
+        {
+            Color color = _palette[colorIndex];
+
+            // Draw text using small rectangles for a pixelated look
+            // This is a simplified approach - a real implementation would use a pixel font
+            DrawString(
+                ThemeDB.FallbackFont,
+                new Vector2(
+                    offsetX + x * PIXEL_SIZE * scale,
+                    offsetY + y * PIXEL_SIZE * scale
+                ),
+                text,
+                HorizontalAlignment.Left,
+                -1,
+                (int)(8 * PIXEL_SIZE * scale),
+                color
+            );
+        }
+
+        // Helper method to draw static noise
+        private void DrawStaticNoise(int x, int y, int width, int height, float intensity, float offsetX, float offsetY, float scale)
+        {
+            if (_noiseGrid == null) return;
+
+            // Only draw some pixels based on intensity
+            Random random = new Random();
+
+            for (int py = 0; py < height; py++)
+            {
+                for (int px = 0; px < width; px++)
+                {
+                    // Skip pixels based on intensity
+                    if (random.NextDouble() > intensity) continue;
+
+                    // Get a noise value from our grid
+                    int gridX = (x + px) % GRID_WIDTH;
+                    int gridY = (y + py) % GRID_HEIGHT;
+                    int colorIndex = _noiseGrid[gridY][gridX];
+
+                    // Draw a single pixel
+                    DrawRect(
+                        new Rect2(
+                            offsetX + (x + px) * PIXEL_SIZE * scale,
+                            offsetY + (y + py) * PIXEL_SIZE * scale,
+                            PIXEL_SIZE * scale,
+                            PIXEL_SIZE * scale
+                        ),
+                        _palette[colorIndex]
+                    );
+                }
+            }
+        }
+
+        // Helper method to draw a signal wave
+        private void DrawSignalWave(int x, int y, int width, int height, float strength, float offsetX, float offsetY, float scale)
+        {
+            int centerY = y + height / 2;
+            int amplitude = (int)(height / 3 * strength);
+
+            // Draw a sine wave
+            for (int px = 0; px < width; px++)
+            {
+                float phase = (float)px / width * Mathf.Pi * 8; // 4 complete waves
+                int waveY = centerY + (int)(Mathf.Sin(phase) * amplitude);
+
+                // Draw a pixel of the wave
+                DrawRect(
+                    new Rect2(
+                        offsetX + (x + px) * PIXEL_SIZE * scale,
+                        offsetY + waveY * PIXEL_SIZE * scale,
+                        PIXEL_SIZE * scale,
+                        PIXEL_SIZE * scale
+                    ),
+                    _palette[8] // Yellow
+                );
+            }
+        }
+
+
+
+        // Handle input events
+        public override void _GuiInput(InputEvent @event)
+        {
+            // Calculate the scale to fit our pixel grid to the actual screen size
+            Vector2 size = Size;
+            float scaleX = size.X / (GRID_WIDTH * PIXEL_SIZE);
+            float scaleY = size.Y / (GRID_HEIGHT * PIXEL_SIZE);
+            float scale = Mathf.Min(scaleX, scaleY);
+
+            // Center the pixel grid on screen
+            float offsetX = (size.X - (GRID_WIDTH * PIXEL_SIZE * scale)) / 2;
+            float offsetY = (size.Y - (GRID_HEIGHT * PIXEL_SIZE * scale)) / 2;
+
+            // Handle mouse button events
+            if (@event is InputEventMouseButton mouseButtonEvent)
+            {
+                if (mouseButtonEvent.ButtonIndex == MouseButton.Left)
+                {
+                    Vector2 mousePos = mouseButtonEvent.Position;
+
+                    // Convert screen coordinates to our pixel grid coordinates
+                    int pixelX = (int)((mousePos.X - offsetX) / (PIXEL_SIZE * scale));
+                    int pixelY = (int)((mousePos.Y - offsetY) / (PIXEL_SIZE * scale));
+
+                    // Check if click is within our grid
+                    if (pixelX >= 0 && pixelX < GRID_WIDTH && pixelY >= 0 && pixelY < GRID_HEIGHT)
+                    {
+                        if (mouseButtonEvent.Pressed)
+                        {
+                            // Button positions
+                            int buttonY = GRID_HEIGHT - 30;
+                            int buttonHeight = 15;
+
+                            // Check power button
+                            if (IsPointInRect(pixelX, pixelY, 10, buttonY, 30, buttonHeight))
+                            {
+                                _isPowerOn = !_isPowerOn;
+                                if (!_isPowerOn) _isScanning = false; // Turn off scanning when power is off
+                            }
+                            // Check scan button
+                            else if (IsPointInRect(pixelX, pixelY, 45, buttonY, 30, buttonHeight) && _isPowerOn)
+                            {
+                                _isScanning = !_isScanning;
+                            }
+                            // Check tune down button
+                            else if (IsPointInRect(pixelX, pixelY, GRID_WIDTH - 75, buttonY, 20, buttonHeight) && _isPowerOn)
+                            {
+                                _currentFrequency -= 0.1f;
+                                if (_currentFrequency < _minFrequency)
+                                    _currentFrequency = _minFrequency;
+
+                                // Generate random signal strength when tuning
+                                _signalStrength = (float)GD.RandRange(0.0, 1.0);
+                            }
+                            // Check tune up button
+                            else if (IsPointInRect(pixelX, pixelY, GRID_WIDTH - 30, buttonY, 20, buttonHeight) && _isPowerOn)
+                            {
+                                _currentFrequency += 0.1f;
+                                if (_currentFrequency > _maxFrequency)
+                                    _currentFrequency = _maxFrequency;
+
+                                // Generate random signal strength when tuning
+                                _signalStrength = (float)GD.RandRange(0.0, 1.0);
+                            }
+                            // Check slider
+                            else if (_isPowerOn)
+                            {
+                                int sliderY = GRID_HEIGHT / 2;
+                                int sliderHeight = 8;
+
+                                if (IsPointInRect(pixelX, pixelY, 10, sliderY - 2, GRID_WIDTH - 20, sliderHeight + 4))
+                                {
+                                    _isDraggingSlider = true;
+                                    UpdateFrequencyFromPixelPosition(pixelX);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // Mouse released
+                            _isDraggingSlider = false;
+                        }
+                    }
+                }
+            }
+            // Handle mouse motion events
+            else if (@event is InputEventMouseMotion mouseMotionEvent && _isDraggingSlider && _isPowerOn)
+            {
+                // Convert screen coordinates to our pixel grid coordinates
+                int pixelX = (int)((mouseMotionEvent.Position.X - offsetX) / (PIXEL_SIZE * scale));
+
+                // Update frequency based on pixel position
+                UpdateFrequencyFromPixelPosition(pixelX);
+            }
+        }
+
+        // Helper to check if a point is in a rectangle
+        private bool IsPointInRect(int x, int y, int rectX, int rectY, int rectWidth, int rectHeight)
+        {
+            return x >= rectX && x < rectX + rectWidth && y >= rectY && y < rectY + rectHeight;
+        }
+
+        // Update frequency based on pixel position
+        private void UpdateFrequencyFromPixelPosition(int pixelX)
+        {
+            // Clamp to slider bounds
+            pixelX = Mathf.Clamp(pixelX, 10, GRID_WIDTH - 10);
+
+            // Calculate percentage along slider
+            float percentage = (float)(pixelX - 10) / (GRID_WIDTH - 20 - 6);
+            percentage = Mathf.Clamp(percentage, 0, 1);
+
+            // Calculate new frequency
+            float frequencyRange = _maxFrequency - _minFrequency;
+            float newFrequency = _minFrequency + percentage * frequencyRange;
+
+            // Round to nearest 0.1
+            _currentFrequency = Mathf.Snapped(newFrequency, 0.1f);
+
+            // Generate random signal strength when tuning
+            _signalStrength = (float)GD.RandRange(0.0, 1.0);
+        }
+
+
+
+        // Called when the control is resized
+        public override void _Notification(int what)
+        {
+            base._Notification(what);
+
+            if (what == NotificationResized)
+            {
+                // Our pixel grid automatically scales with the window size
+                QueueRedraw();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds two new signal strength indicator components:

1. SignalStrengthIndicator - A standard bar-based indicator
2. PixelSignalStrengthIndicator - A retro pixel art style indicator

Also includes:
- SignalStrengthTest scene for testing and demonstrating the indicators
- SimpleRadioTest class for a complete pixel-based radio interface

These components will enhance the visual feedback for radio signal strength in the game, providing both a standard UI option and a pixel art style option that matches the game's retro aesthetic.

The indicators can be easily integrated with the existing RadioTuner component to provide visual feedback on signal strength.