### PR TITLE
Fix build errors in test files

### DIFF
--- a/godot_project/tests/AudioManagerTests.cs
+++ b/godot_project/tests/AudioManagerTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace SignalLost.Tests
 {
 	[GlobalClass]
-	[TestClass]
+	[Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
 	public partial class AudioManagerTests : Test
 	{
 		private AudioManager _audioManager = null;

--- a/godot_project/tests/AudioVisualizerTests.cs
+++ b/godot_project/tests/AudioVisualizerTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace SignalLost.Tests
 {
     [GlobalClass]
-    [TestClass]
+    [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
     public partial class AudioVisualizerTests : Test
     {
         private AudioVisualizer _audioVisualizer = null;
@@ -33,7 +33,7 @@ namespace SignalLost.Tests
         }
 
         // Test initialization
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestInitialization()
         {
             // Assert default properties are set correctly
@@ -57,7 +57,7 @@ namespace SignalLost.Tests
         }
 
         // Test signal strength setting
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestSetSignalStrength()
         {
             // Arrange
@@ -88,7 +88,7 @@ namespace SignalLost.Tests
         }
 
         // Test static intensity setting
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestSetStaticIntensity()
         {
             // Arrange
@@ -119,7 +119,7 @@ namespace SignalLost.Tests
         }
 
         // Test bar height calculation
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestBarHeightCalculation()
         {
             // This is a more complex test as CalculateBarHeight is private
@@ -156,7 +156,7 @@ namespace SignalLost.Tests
         }
 
         // Test that the visualizer responds to both signal and static
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestSignalAndStaticVisualization()
         {
             // Set both signal and static to non-zero values

--- a/godot_project/tests/GameStateTests.cs
+++ b/godot_project/tests/GameStateTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace SignalLost.Tests
 {
     [GlobalClass]
-    [TestClass]
+    [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
     public partial class GameStateTests : Test
     {
         private GameState _gameState = null;
@@ -28,7 +28,7 @@ namespace SignalLost.Tests
         }
 
         // Test frequency setting
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestSetFrequency()
         {
             // Arrange
@@ -44,7 +44,7 @@ namespace SignalLost.Tests
         }
 
         // Test frequency limits
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestFrequencyLimits()
         {
             // Arrange
@@ -67,7 +67,7 @@ namespace SignalLost.Tests
         }
 
         // Test radio toggle
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestToggleRadio()
         {
             // Arrange
@@ -89,7 +89,7 @@ namespace SignalLost.Tests
         }
 
         // Test signal detection
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestFindSignalAtFrequency()
         {
             // Arrange
@@ -107,7 +107,7 @@ namespace SignalLost.Tests
         }
 
         // Test signal strength calculation
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestCalculateSignalStrength()
         {
             // Arrange
@@ -127,7 +127,7 @@ namespace SignalLost.Tests
         }
 
         // Test discovered frequencies
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestAddDiscoveredFrequency()
         {
             // Arrange
@@ -152,7 +152,7 @@ namespace SignalLost.Tests
         }
 
         // Test message decoding
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestDecodeMessage()
         {
             // Arrange
@@ -173,7 +173,7 @@ namespace SignalLost.Tests
         }
 
         // Test static intensity
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestGetStaticIntensity()
         {
             // Arrange

--- a/godot_project/tests/IntegrationTests.cs
+++ b/godot_project/tests/IntegrationTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SignalLost.Tests
 {
-    [TestClass]
+    [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
     public partial class IntegrationTests : Test
     {
         // Components to test
@@ -164,7 +164,7 @@ namespace SignalLost.Tests
         }
 
         // Test GameState and AudioManager integration
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestGameStateAudioManagerIntegration()
         {
             // Skip this test if components are not properly initialized
@@ -224,7 +224,7 @@ namespace SignalLost.Tests
         }
 
         // Test RadioTuner and GameState integration
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestRadioTunerGameStateIntegration()
         {
             // Skip this test on Mac
@@ -282,7 +282,7 @@ namespace SignalLost.Tests
         }
 
         // Test signal discovery and message decoding
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestSignalDiscoveryAndMessageDecoding()
         {
             // Skip this test if components are not properly initialized
@@ -356,7 +356,7 @@ namespace SignalLost.Tests
         }
 
         // Test scanning functionality with signal discovery
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestScanningWithSignalDiscovery()
         {
             // Skip this test if components are not properly initialized
@@ -436,7 +436,7 @@ namespace SignalLost.Tests
         }
 
         // Test edge case: radio behavior at frequency boundaries
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestFrequencyBoundaries()
         {
             // Skip this test if components are not properly initialized

--- a/godot_project/tests/InventorySystemTests.cs
+++ b/godot_project/tests/InventorySystemTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SignalLost.Tests
 {
-    [TestClass]
+    [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
     public partial class InventorySystemTests : Node
     {
         private InventorySystem _inventorySystem;
@@ -47,7 +47,7 @@ namespace SignalLost.Tests
         }
 
         // Test getting an item from the database
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestGetItem()
         {
             // Arrange
@@ -71,7 +71,7 @@ namespace SignalLost.Tests
         }
 
         // Test adding an item to the inventory
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestAddItemToInventory()
         {
             // Arrange
@@ -96,7 +96,7 @@ namespace SignalLost.Tests
         }
 
         // Test adding multiple items to the inventory
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestAddMultipleItems()
         {
             // Arrange
@@ -122,7 +122,7 @@ namespace SignalLost.Tests
         }
 
         // Test removing an item from the inventory
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestRemoveItemFromInventory()
         {
             // Arrange
@@ -153,7 +153,7 @@ namespace SignalLost.Tests
         }
 
         // Test using an item
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestUseItem()
         {
             // Arrange
@@ -186,7 +186,7 @@ namespace SignalLost.Tests
         }
 
         // Test inventory capacity
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestInventoryCapacity()
         {
             // Arrange
@@ -215,7 +215,7 @@ namespace SignalLost.Tests
         }
 
         // Test getting items by category
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestGetItemsByCategory()
         {
             // Arrange

--- a/godot_project/tests/MapSystemTests.cs
+++ b/godot_project/tests/MapSystemTests.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SignalLost.Tests
 {
-    [TestClass]
+    [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
     public partial class MapSystemTests : Node
     {
         private TestMapSystem _mapSystem;
@@ -34,7 +34,7 @@ namespace SignalLost.Tests
         }
 
         // Test getting a location
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestGetLocation()
         {
             // Arrange
@@ -58,7 +58,7 @@ namespace SignalLost.Tests
         }
 
         // Test discovering a location
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestDiscoverLocation()
         {
             // Arrange
@@ -81,7 +81,7 @@ namespace SignalLost.Tests
         }
 
         // Test changing location
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestChangeLocation()
         {
             // Arrange
@@ -112,7 +112,7 @@ namespace SignalLost.Tests
         }
 
         // Test getting connected locations
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestGetConnectedLocations()
         {
             // Arrange
@@ -155,7 +155,7 @@ namespace SignalLost.Tests
         }
 
         // Test location connection check
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestIsLocationConnected()
         {
             // Arrange

--- a/godot_project/tests/PixelInventoryUITests.cs
+++ b/godot_project/tests/PixelInventoryUITests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SignalLost.Tests
 {
-    [TestClass]
+    [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
     public partial class PixelInventoryUITests : Test
     {
         private PixelInventoryUI _inventoryUI;
@@ -43,7 +43,7 @@ namespace SignalLost.Tests
             _gameState.QueueFree();
         }
 
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestInitialization()
         {
             // Verify that the inventory UI is initialized correctly
@@ -51,7 +51,7 @@ namespace SignalLost.Tests
             Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsFalse(_inventoryUI.IsVisible(), "PixelInventoryUI should be hidden by default");
         }
 
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestVisibility()
         {
             // Test setting visibility
@@ -69,7 +69,7 @@ namespace SignalLost.Tests
             Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsFalse(_inventoryUI.IsVisible(), "PixelInventoryUI should be hidden after ToggleVisibility()");
         }
 
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestInventoryChanges()
         {
             // Add items to the inventory
@@ -90,7 +90,7 @@ namespace SignalLost.Tests
             Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreEqual(2, _inventorySystem.GetTotalItemCount(), "Inventory should have 2 items after removing battery");
         }
 
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestInputHandling()
         {
             // Make the inventory UI visible

--- a/godot_project/tests/PixelMapInterfaceTests.cs
+++ b/godot_project/tests/PixelMapInterfaceTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SignalLost.Tests
 {
-    [TestClass]
+    [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
     public partial class PixelMapInterfaceTests : Test
     {
         private PixelMapInterface _mapInterface;
@@ -43,7 +43,7 @@ namespace SignalLost.Tests
             _gameState.QueueFree();
         }
 
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestInitialization()
         {
             // Verify that the map interface is initialized correctly
@@ -51,7 +51,7 @@ namespace SignalLost.Tests
             Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsFalse(_mapInterface.IsVisible(), "PixelMapInterface should be hidden by default");
         }
 
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestVisibility()
         {
             // Test setting visibility
@@ -69,7 +69,7 @@ namespace SignalLost.Tests
             Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsFalse(_mapInterface.IsVisible(), "PixelMapInterface should be hidden after ToggleVisibility()");
         }
 
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestLocationDiscovery()
         {
             // Make the map interface visible
@@ -83,7 +83,7 @@ namespace SignalLost.Tests
             Microsoft.VisualStudio.TestTools.UnitTesting.Assert.IsTrue(location.IsDiscovered, "Forest location should be discovered");
         }
 
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestLocationChange()
         {
             // Make the map interface visible
@@ -97,7 +97,7 @@ namespace SignalLost.Tests
             Microsoft.VisualStudio.TestTools.UnitTesting.Assert.AreEqual("forest", _gameState.CurrentLocation, "Current location should be forest");
         }
 
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestInputHandling()
         {
             // Make the map interface visible

--- a/godot_project/tests/QuestSystemTests.cs
+++ b/godot_project/tests/QuestSystemTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SignalLost.Tests
 {
-    [TestClass]
+    [Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
     public partial class QuestSystemTests : Node
     {
         private QuestSystem _questSystem;
@@ -75,7 +75,7 @@ namespace SignalLost.Tests
         }
 
         // Test getting a quest from the database
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestGetQuest()
         {
             // Arrange
@@ -101,7 +101,7 @@ namespace SignalLost.Tests
         }
 
         // Test activating a quest
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestActivateQuest()
         {
             // Arrange
@@ -127,7 +127,7 @@ namespace SignalLost.Tests
         }
 
         // Test completing a quest objective
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestUpdateQuestObjective()
         {
             // Arrange
@@ -161,7 +161,7 @@ namespace SignalLost.Tests
         }
 
         // Test quest prerequisites
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestQuestPrerequisites()
         {
             // Arrange
@@ -199,7 +199,7 @@ namespace SignalLost.Tests
         }
 
         // Test location-based quest discovery
-        [TestMethod]
+        [Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
         public void TestLocationBasedQuestDiscovery()
         {
             // Arrange

--- a/godot_project/tests/RadioTunerTests.cs
+++ b/godot_project/tests/RadioTunerTests.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace SignalLost.Tests
 {
-	[TestClass]
+	[Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
 	public partial class RadioTunerTests : Test
 	{
 		// Path to the scene we want to test
@@ -129,7 +129,7 @@ namespace SignalLost.Tests
 		}
 
 		// Test power button functionality
-		[TestMethod]
+		[Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
 		public void TestPowerButton()
 		{
 			// Skip this test if components are not properly initialized
@@ -181,7 +181,7 @@ namespace SignalLost.Tests
 		}
 
 		// Test frequency change
-		[TestMethod]
+		[Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
 		public void TestFrequencyChange()
 		{
 			// Skip this test if components are not properly initialized
@@ -233,7 +233,7 @@ namespace SignalLost.Tests
 		}
 
 		// Test signal detection
-		[TestMethod]
+		[Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
 		public void TestSignalDetection()
 		{
 			// Skip this test if components are not properly initialized
@@ -306,7 +306,7 @@ namespace SignalLost.Tests
 		}
 
 		// Test scanning functionality
-		[TestMethod]
+		[Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
 		public void TestScanning()
 		{
 			// Skip this test if components are not properly initialized
@@ -357,7 +357,7 @@ namespace SignalLost.Tests
 		}
 
 		// Test message display
-		[TestMethod]
+		[Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
 		public void TestMessageDisplay()
 		{
 			// Skip this test if components are not properly initialized
@@ -423,7 +423,7 @@ namespace SignalLost.Tests
 		}
 
 		// Test radio behavior when turned off
-		[TestMethod]
+		[Microsoft.VisualStudio.TestTools.UnitTesting.TestMethod]
 		public void TestRadioOffBehavior()
 		{
 			// Skip this test on Mac


### PR DESCRIPTION
This PR fixes the build errors in the test files by fully qualifying the TestClass and TestMethod attributes to resolve ambiguous references between GUT.TestClassAttribute and Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute.\n\nChanges:\n- Fully qualified all TestClass and TestMethod attributes in test files\n- The project now builds successfully\n- 57 out of 61 tests are now passing\n\nRemaining issues to be addressed in future PRs:\n1. 4 failing tests related to the pixel-based UI migration\n2. Node path errors in RadioPanel (tests looking for old RadioTuner nodes)\n3. Missing audio resources\n\nThese fixes are a first step towards getting the project back to a working state after the migration to pixel-based UI.