### PR TITLE
Fix build errors by adding missing classes and fixing method overrides

### DIFF
--- a/godot_project/scripts/RadioTuner.cs
+++ b/godot_project/scripts/RadioTuner.cs
@@ -1,0 +1,104 @@
+using Godot;
+using System;
+
+namespace SignalLost
+{
+    /// <summary>
+    /// A simplified RadioTuner class to support tests
+    /// </summary>
+    [GlobalClass]
+    public partial class RadioTuner : Control
+    {
+        // Constants for frequency limits
+        private const float MinFrequency = 88.0f;
+        private const float MaxFrequency = 108.0f;
+
+        // Reference to the GameState
+        private GameState _gameState;
+
+        // UI state
+        private bool _isScanning = false;
+        private bool _showMessage = false;
+        private string _currentSignalId = "";
+        private float _signalStrength = 0.0f;
+        private float _staticIntensity = 0.5f;
+
+        // Called when the node enters the scene tree for the first time
+        public override void _Ready()
+        {
+            // Get the GameState singleton
+            _gameState = GetNode<GameState>("/root/GameState");
+            
+            // Connect to GameState signals
+            _gameState.RadioToggled += OnRadioToggled;
+            _gameState.FrequencyChanged += OnFrequencyChanged;
+        }
+
+        // Called when the radio is toggled
+        public void OnRadioToggled(bool isOn)
+        {
+            // If radio is turned off, stop scanning
+            if (!isOn && _isScanning)
+            {
+                _isScanning = false;
+            }
+        }
+
+        // Called when the frequency is changed
+        public void OnFrequencyChanged(float frequency)
+        {
+            // Process the new frequency
+            ProcessFrequency(frequency);
+        }
+
+        // Process the current frequency
+        private void ProcessFrequency(float frequency)
+        {
+            // Find signal at the current frequency
+            var signalData = _gameState.FindSignalAtFrequency(frequency);
+            
+            if (signalData != null)
+            {
+                // Calculate signal strength
+                float strength = _gameState.CalculateSignalStrength(frequency, signalData);
+                
+                // Update state
+                _signalStrength = strength;
+                _staticIntensity = 1.0f - strength;
+                _currentSignalId = signalData.MessageId;
+                
+                // Add to discovered frequencies if signal is strong enough
+                if (strength > 0.7f)
+                {
+                    _gameState.AddDiscoveredFrequency(signalData.Frequency);
+                }
+            }
+            else
+            {
+                // No signal, just static
+                _signalStrength = 0.1f;
+                _staticIntensity = 0.9f;
+                _currentSignalId = "";
+            }
+        }
+
+        // Toggle the radio power
+        public void TogglePower()
+        {
+            _gameState.ToggleRadio();
+        }
+
+        // Change the frequency
+        public void ChangeFrequency(float amount)
+        {
+            // Calculate new frequency
+            float newFrequency = _gameState.CurrentFrequency + amount;
+            
+            // Clamp to valid range
+            newFrequency = Mathf.Clamp(newFrequency, MinFrequency, MaxFrequency);
+            
+            // Update GameState
+            _gameState.SetFrequency(newFrequency);
+        }
+    }
+}

--- a/godot_project/tests/AudioManagerTests.cs
+++ b/godot_project/tests/AudioManagerTests.cs
@@ -11,7 +11,7 @@ namespace SignalLost.Tests
 		private AudioManager _audioManager = null;
 
 		// Called before each test
-		public void Before()
+		public override void Before()
 		{
 			try
 			{
@@ -86,7 +86,7 @@ namespace SignalLost.Tests
 		}
 
 		// Called after each test
-		public void After()
+		public override void After()
 		{
 			// Clean up
 			if (_audioManager != null)

--- a/godot_project/tests/GameStateTests.cs
+++ b/godot_project/tests/GameStateTests.cs
@@ -11,7 +11,7 @@ namespace SignalLost.Tests
         private GameState _gameState = null;
 
         // Called before each test
-        public void Before()
+        public override void Before()
         {
             // Create a new instance of the GameState
             _gameState = new GameState();
@@ -20,7 +20,7 @@ namespace SignalLost.Tests
         }
 
         // Called after each test
-        public void After()
+        public override void After()
         {
             // Clean up
             _gameState.QueueFree();

--- a/godot_project/tests/IntegrationTests.cs
+++ b/godot_project/tests/IntegrationTests.cs
@@ -15,7 +15,7 @@ namespace SignalLost.Tests
         private PackedScene _radioTunerScene;
 
         // Called before each test
-        public void Before()
+        public override void Before()
         {
             try
             {
@@ -151,7 +151,7 @@ namespace SignalLost.Tests
         }
 
         // Called after each test
-        public void After()
+        public override void After()
         {
             // Clean up
             _radioTuner.QueueFree();

--- a/godot_project/tests/PixelInventoryUITests.cs
+++ b/godot_project/tests/PixelInventoryUITests.cs
@@ -13,7 +13,7 @@ namespace SignalLost.Tests
         private GameState _gameState;
 
         // Setup method called before each test
-        public void Before()
+        public override void Before()
         {
             // Create a mock GameState
             _gameState = new GameState();
@@ -35,7 +35,7 @@ namespace SignalLost.Tests
         }
 
         // Teardown method called after each test
-        public void After()
+        public override void After()
         {
             // Remove nodes
             _inventoryUI.QueueFree();

--- a/godot_project/tests/PixelMapInterfaceTests.cs
+++ b/godot_project/tests/PixelMapInterfaceTests.cs
@@ -13,7 +13,7 @@ namespace SignalLost.Tests
         private GameState _gameState;
 
         // Setup method called before each test
-        public void Before()
+        public override void Before()
         {
             // Create a mock GameState
             _gameState = new GameState();
@@ -35,7 +35,7 @@ namespace SignalLost.Tests
         }
 
         // Teardown method called after each test
-        public void After()
+        public override void After()
         {
             // Remove nodes
             _mapInterface.QueueFree();

--- a/godot_project/tests/RadioTunerTests.cs
+++ b/godot_project/tests/RadioTunerTests.cs
@@ -18,7 +18,7 @@ namespace SignalLost.Tests
 		private const float MaxFrequency = 108.0f;
 
 		// Called before each test
-		public void Before()
+		public override void Before()
 		{
 			try
 			{
@@ -121,7 +121,7 @@ namespace SignalLost.Tests
 		}
 
 		// Called after each test
-		public void After()
+		public override void After()
 		{
 			// Clean up
 			_radioTuner.QueueFree();

--- a/godot_project/tests/TestMapSystem.cs
+++ b/godot_project/tests/TestMapSystem.cs
@@ -1,0 +1,186 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+
+namespace SignalLost.Tests
+{
+    /// <summary>
+    /// A simplified TestMapSystem class for testing
+    /// </summary>
+    [GlobalClass]
+    public partial class TestMapSystem : Node
+    {
+        // Current location
+        private string _currentLocation = "bunker";
+        
+        // Dictionary of locations
+        private Dictionary<string, MapLocation> _locations = new Dictionary<string, MapLocation>();
+        
+        // Dictionary of connections between locations
+        private Dictionary<string, List<string>> _connections = new Dictionary<string, List<string>>();
+        
+        // Called when the node enters the scene tree for the first time
+        public override void _Ready()
+        {
+            // Initialize locations
+            InitializeLocations();
+            
+            // Initialize connections
+            InitializeConnections();
+        }
+        
+        // Initialize test locations
+        private void InitializeLocations()
+        {
+            // Add test locations
+            _locations.Add("bunker", new MapLocation
+            {
+                Id = "bunker",
+                Name = "Emergency Bunker",
+                Description = "A concrete bunker built for emergencies.",
+                IsDiscovered = true
+            });
+            
+            _locations.Add("forest", new MapLocation
+            {
+                Id = "forest",
+                Name = "Dense Forest",
+                Description = "A thick forest with tall trees.",
+                IsDiscovered = false
+            });
+            
+            _locations.Add("road", new MapLocation
+            {
+                Id = "road",
+                Name = "Abandoned Road",
+                Description = "An old road that hasn't been used in years.",
+                IsDiscovered = false
+            });
+            
+            _locations.Add("lake", new MapLocation
+            {
+                Id = "lake",
+                Name = "Misty Lake",
+                Description = "A small lake surrounded by mist.",
+                IsDiscovered = false
+            });
+            
+            _locations.Add("cabin", new MapLocation
+            {
+                Id = "cabin",
+                Name = "Old Cabin",
+                Description = "A weathered wooden cabin in the woods.",
+                IsDiscovered = false
+            });
+        }
+        
+        // Initialize connections between locations
+        private void InitializeConnections()
+        {
+            // Add connections
+            _connections.Add("bunker", new List<string> { "forest", "road" });
+            _connections.Add("forest", new List<string> { "bunker", "lake", "cabin" });
+            _connections.Add("road", new List<string> { "bunker", "cabin" });
+            _connections.Add("lake", new List<string> { "forest" });
+            _connections.Add("cabin", new List<string> { "forest", "road" });
+        }
+        
+        // Get a location by ID
+        public MapLocation GetLocation(string locationId)
+        {
+            if (_locations.ContainsKey(locationId))
+            {
+                return _locations[locationId];
+            }
+            
+            return null;
+        }
+        
+        // Get the current location ID
+        public string GetCurrentLocation()
+        {
+            return _currentLocation;
+        }
+        
+        // Get all locations
+        public List<MapLocation> GetAllLocations()
+        {
+            List<MapLocation> result = new List<MapLocation>();
+            
+            foreach (var location in _locations.Values)
+            {
+                result.Add(location);
+            }
+            
+            return result;
+        }
+        
+        // Get locations connected to the current location
+        public List<MapLocation> GetConnectedLocations()
+        {
+            List<MapLocation> result = new List<MapLocation>();
+            
+            if (_connections.ContainsKey(_currentLocation))
+            {
+                foreach (var locationId in _connections[_currentLocation])
+                {
+                    if (_locations.ContainsKey(locationId))
+                    {
+                        result.Add(_locations[locationId]);
+                    }
+                }
+            }
+            
+            return result;
+        }
+        
+        // Check if a location is connected to the current location
+        public bool IsLocationConnected(string locationId)
+        {
+            if (_connections.ContainsKey(_currentLocation))
+            {
+                return _connections[_currentLocation].Contains(locationId);
+            }
+            
+            return false;
+        }
+        
+        // Discover a location
+        public bool DiscoverLocation(string locationId)
+        {
+            if (_locations.ContainsKey(locationId))
+            {
+                _locations[locationId].IsDiscovered = true;
+                return true;
+            }
+            
+            return false;
+        }
+        
+        // Change the current location
+        public bool ChangeLocation(string locationId)
+        {
+            // Check if the location exists and is discovered
+            if (_locations.ContainsKey(locationId) && _locations[locationId].IsDiscovered)
+            {
+                // Check if the location is connected to the current location
+                if (IsLocationConnected(locationId))
+                {
+                    _currentLocation = locationId;
+                    return true;
+                }
+            }
+            
+            return false;
+        }
+    }
+    
+    // MapLocation class
+    public class MapLocation
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public bool IsDiscovered { get; set; }
+    }
+}


### PR DESCRIPTION
This PR fixes the build errors that were occurring after the cleanup:

1. Added a simplified RadioTuner class to replace the deleted one
2. Added a TestMapSystem class to replace the deleted one
3. Fixed method override issues in test classes:
   - Added 'override' keyword to Before() and After() methods in:
     - IntegrationTests
     - RadioTunerTests
     - AudioManagerTests
     - PixelInventoryUITests
     - PixelMapInterfaceTests
     - GameStateTests

The build now succeeds with only minor warnings about unreachable code in test files.