### PR TITLE
Fix CI build errors by using 'new' instead of 'override' for test methods

### DIFF
--- a/godot_project/tests/AudioManagerTests.cs
+++ b/godot_project/tests/AudioManagerTests.cs
@@ -11,7 +11,7 @@ namespace SignalLost.Tests
 		private AudioManager _audioManager = null;
 
 		// Called before each test
-		public override void Before()
+		public new void Before()
 		{
 			try
 			{
@@ -86,7 +86,7 @@ namespace SignalLost.Tests
 		}
 
 		// Called after each test
-		public override void After()
+		public new void After()
 		{
 			// Clean up
 			if (_audioManager != null)

--- a/godot_project/tests/GameStateTests.cs
+++ b/godot_project/tests/GameStateTests.cs
@@ -11,7 +11,7 @@ namespace SignalLost.Tests
         private GameState _gameState = null;
 
         // Called before each test
-        public override void Before()
+        public new void Before()
         {
             // Create a new instance of the GameState
             _gameState = new GameState();
@@ -20,7 +20,7 @@ namespace SignalLost.Tests
         }
 
         // Called after each test
-        public override void After()
+        public new void After()
         {
             // Clean up
             _gameState.QueueFree();

--- a/godot_project/tests/IntegrationTests.cs
+++ b/godot_project/tests/IntegrationTests.cs
@@ -15,7 +15,7 @@ namespace SignalLost.Tests
         private PackedScene _radioTunerScene;
 
         // Called before each test
-        public override void Before()
+        public new void Before()
         {
             try
             {
@@ -151,7 +151,7 @@ namespace SignalLost.Tests
         }
 
         // Called after each test
-        public override void After()
+        public new void After()
         {
             // Clean up
             _radioTuner.QueueFree();

--- a/godot_project/tests/PixelInventoryUITests.cs
+++ b/godot_project/tests/PixelInventoryUITests.cs
@@ -13,7 +13,7 @@ namespace SignalLost.Tests
         private GameState _gameState;
 
         // Setup method called before each test
-        public override void Before()
+        public new void Before()
         {
             // Create a mock GameState
             _gameState = new GameState();
@@ -35,7 +35,7 @@ namespace SignalLost.Tests
         }
 
         // Teardown method called after each test
-        public override void After()
+        public new void After()
         {
             // Remove nodes
             _inventoryUI.QueueFree();

--- a/godot_project/tests/PixelMapInterfaceTests.cs
+++ b/godot_project/tests/PixelMapInterfaceTests.cs
@@ -13,7 +13,7 @@ namespace SignalLost.Tests
         private GameState _gameState;
 
         // Setup method called before each test
-        public override void Before()
+        public new void Before()
         {
             // Create a mock GameState
             _gameState = new GameState();
@@ -35,7 +35,7 @@ namespace SignalLost.Tests
         }
 
         // Teardown method called after each test
-        public override void After()
+        public new void After()
         {
             // Remove nodes
             _mapInterface.QueueFree();

--- a/godot_project/tests/RadioTunerTests.cs
+++ b/godot_project/tests/RadioTunerTests.cs
@@ -18,7 +18,7 @@ namespace SignalLost.Tests
 		private const float MaxFrequency = 108.0f;
 
 		// Called before each test
-		public override void Before()
+		public new void Before()
 		{
 			try
 			{
@@ -121,7 +121,7 @@ namespace SignalLost.Tests
 		}
 
 		// Called after each test
-		public override void After()
+		public new void After()
 		{
 			// Clean up
 			_radioTuner.QueueFree();


### PR DESCRIPTION
This PR fixes the CI build errors that were occurring in PR #128:

1. Changed all test methods from using override to using 
ew for:
   - Before() methods
   - After() methods

This change is necessary because the Test class in the CI environment doesn't have the same method signatures as in our local environment.

The build now succeeds with only minor warnings about unreachable code in test files.