### PR TITLE
Add pixel drawing demo for visual development

### DIFF
--- a/godot_project/Scenes/PixelDrawingDemo.tscn
+++ b/godot_project/Scenes/PixelDrawingDemo.tscn
@@ -1,0 +1,105 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/PixelDrawingDemo.cs" id="1_demo"]
+
+[node name="PixelDrawingDemo" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_demo")
+
+[node name="ControlPanel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 0
+anchor_left = 0.7
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 0
+grow_vertical = 2
+
+[node name="Title" type="Label" parent="ControlPanel"]
+layout_mode = 1
+anchors_preset = 10
+anchor_right = 1.0
+offset_top = 20.0
+offset_bottom = 46.0
+grow_horizontal = 2
+text = "Pixel Drawing Demo"
+horizontal_alignment = 1
+
+[node name="GridSizeLabel" type="Label" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 20.0
+offset_top = 60.0
+offset_right = 120.0
+offset_bottom = 86.0
+text = "Grid Size:"
+
+[node name="GridSizeSpinBox" type="SpinBox" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 120.0
+offset_top = 60.0
+offset_right = 280.0
+offset_bottom = 91.0
+min_value = 1.0
+max_value = 32.0
+value = 8.0
+rounded = true
+
+[node name="PixelColorLabel" type="Label" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 20.0
+offset_top = 100.0
+offset_right = 120.0
+offset_bottom = 126.0
+text = "Pixel Color:"
+
+[node name="PixelColorPicker" type="ColorPickerButton" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 120.0
+offset_top = 100.0
+offset_right = 280.0
+offset_bottom = 131.0
+color = Color(0, 0.8, 0, 1)
+
+[node name="ClearButton" type="Button" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 20.0
+offset_top = 150.0
+offset_right = 280.0
+offset_bottom = 181.0
+text = "Clear"
+
+[node name="SaveButton" type="Button" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 20.0
+offset_top = 190.0
+offset_right = 280.0
+offset_bottom = 221.0
+text = "Save"
+
+[node name="LoadButton" type="Button" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 20.0
+offset_top = 230.0
+offset_right = 280.0
+offset_bottom = 261.0
+text = "Load"
+
+[node name="InfoLabel" type="Label" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 20.0
+offset_top = 280.0
+offset_right = 280.0
+offset_bottom = 500.0
+text = "Grid Size: 8px
+Grid Dimensions: 0 x 0
+Active Pixels: 0 (0.00%)
+
+Left-click to draw
+Right-click to erase
+Shift+click to draw lines"
+autowrap_mode = 3

--- a/godot_project/Scenes/PixelVisualizationSandbox.tscn
+++ b/godot_project/Scenes/PixelVisualizationSandbox.tscn
@@ -1,0 +1,225 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/PixelVisualizationSandbox.cs" id="1_sandbox"]
+[ext_resource type="Script" path="res://scripts/PixelMessageDisplay.cs" id="2_message"]
+[ext_resource type="Script" path="res://scripts/utils/ScreenshotTaker.cs" id="3_screenshot"]
+
+[node name="PixelVisualizationSandbox" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_sandbox")
+
+[node name="Background" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.1, 0.1, 0.1, 1.0)
+
+[node name="PixelMessageDisplay" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 0
+offset_left = 20.0
+offset_top = 20.0
+offset_right = 720.0
+offset_bottom = 520.0
+script = ExtResource("2_message")
+
+[node name="ScreenshotTaker" type="Node" parent="."]
+script = ExtResource("3_screenshot")
+ScreenshotDirectoryName = "PixelSandbox"
+
+[node name="ControlPanel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 0
+offset_left = 740.0
+offset_top = 20.0
+offset_right = 1004.0
+offset_bottom = 580.0
+
+[node name="Title" type="Label" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 254.0
+offset_bottom = 36.0
+text = "Pixel Visualization Controls"
+horizontal_alignment = 1
+
+[node name="MessageTypeLabel" type="Label" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 50.0
+offset_right = 110.0
+offset_bottom = 76.0
+text = "Message Type:"
+
+[node name="MessageTypeDropdown" type="OptionButton" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 120.0
+offset_top = 50.0
+offset_right = 254.0
+offset_bottom = 76.0
+
+[node name="InterferenceLabel" type="Label" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 90.0
+offset_right = 110.0
+offset_bottom = 116.0
+text = "Interference:"
+
+[node name="InterferenceSlider" type="HSlider" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 120.0
+offset_top = 90.0
+offset_right = 254.0
+offset_bottom = 116.0
+
+[node name="CharacterSizeLabel" type="Label" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 130.0
+offset_right = 110.0
+offset_bottom = 156.0
+text = "Char Size:"
+
+[node name="CharacterSizeSpinBox" type="SpinBox" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 120.0
+offset_top = 130.0
+offset_right = 254.0
+offset_bottom = 156.0
+
+[node name="TextColorLabel" type="Label" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 170.0
+offset_right = 110.0
+offset_bottom = 196.0
+text = "Text Color:"
+
+[node name="TextColorPicker" type="ColorPickerButton" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 120.0
+offset_top = 170.0
+offset_right = 254.0
+offset_bottom = 196.0
+
+[node name="BgColorLabel" type="Label" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 210.0
+offset_right = 110.0
+offset_bottom = 236.0
+text = "BG Color:"
+
+[node name="BgColorPicker" type="ColorPickerButton" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 120.0
+offset_top = 210.0
+offset_right = 254.0
+offset_bottom = 236.0
+
+[node name="EnableScanlinesCheckbox" type="CheckBox" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 250.0
+offset_right = 254.0
+offset_bottom = 276.0
+text = "Enable Scanlines"
+
+[node name="EnableFlickerCheckbox" type="CheckBox" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 280.0
+offset_right = 254.0
+offset_bottom = 306.0
+text = "Enable Screen Flicker"
+
+[node name="EnableTypewriterSoundCheckbox" type="CheckBox" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 310.0
+offset_right = 254.0
+offset_bottom = 336.0
+text = "Enable Typewriter Sound"
+
+[node name="ToggleGridButton" type="Button" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 350.0
+offset_right = 120.0
+offset_bottom = 376.0
+text = "Show Grid"
+
+[node name="ToggleAsciiArtButton" type="Button" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 130.0
+offset_top = 350.0
+offset_right = 254.0
+offset_bottom = 376.0
+text = "Show ASCII Art"
+
+[node name="ScreenshotButton" type="Button" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 390.0
+offset_right = 254.0
+offset_bottom = 416.0
+text = "Take Screenshot"
+
+[node name="ContentLabel" type="Label" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 430.0
+offset_right = 254.0
+offset_bottom = 456.0
+text = "Content:"
+
+[node name="ContentInput" type="TextEdit" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 460.0
+offset_right = 254.0
+offset_bottom = 520.0
+wrap_mode = 1
+
+[node name="AsciiArtLabel" type="Label" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 530.0
+offset_right = 254.0
+offset_bottom = 556.0
+text = "ASCII Art:"
+
+[node name="AsciiArtInput" type="TextEdit" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 560.0
+offset_right = 254.0
+offset_bottom = 660.0
+wrap_mode = 0
+
+[node name="DebugInfoLabel" type="Label" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 670.0
+offset_right = 254.0
+offset_bottom = 696.0
+text = "Debug Info:"
+
+[node name="DebugInfo" type="Label" parent="ControlPanel"]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 700.0
+offset_right = 254.0
+offset_bottom = 800.0
+text = "Debug information will appear here."
+autowrap_mode = 3

--- a/godot_project/run_pixel_drawing_demo.bat
+++ b/godot_project/run_pixel_drawing_demo.bat
@@ -1,0 +1,35 @@
+@echo off
+REM This script runs the Pixel Drawing Demo scene
+
+REM Find the Godot executable
+set "GODOT_EXECUTABLE=C:\Godot_v4.4.1-stable_mono_win64\Godot_v4.4.1-stable_mono_win64\Godot_v4.4.1-stable_mono_win64_console.exe"
+
+REM Check if Godot executable exists
+if not exist "%GODOT_EXECUTABLE%" (
+    echo Godot executable not found at %GODOT_EXECUTABLE%
+    echo Please install Godot or update the script with the correct path.
+    exit /b 1
+)
+
+echo Using Godot executable: %GODOT_EXECUTABLE%
+
+REM Get the directory of this script
+set "DIR=%~dp0"
+
+echo Running Pixel Drawing Demo scene...
+echo Project path: %DIR%
+
+REM Run the scene
+cd "%DIR%"
+"%GODOT_EXECUTABLE%" --path . --scene Scenes/PixelDrawingDemo.tscn
+
+REM Get the exit code
+set EXIT_CODE=%ERRORLEVEL%
+
+if %EXIT_CODE% equ 0 (
+    echo Scene ran successfully!
+) else (
+    echo Scene failed to run. See above for details.
+)
+
+exit /b %EXIT_CODE%

--- a/godot_project/run_pixel_drawing_demo.sh
+++ b/godot_project/run_pixel_drawing_demo.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# This script runs the Pixel Drawing Demo scene
+
+# Function to find Godot executable
+find_godot() {
+    # Check if GODOT_EXECUTABLE environment variable is set
+    if [ ! -z "$GODOT_EXECUTABLE" ]; then
+        if [ -f "$GODOT_EXECUTABLE" ]; then
+            echo "$GODOT_EXECUTABLE"
+            return 0
+        else
+            echo "Warning: GODOT_EXECUTABLE is set but the file does not exist: $GODOT_EXECUTABLE"
+        fi
+    fi
+
+    # Check if Godot is in PATH
+    if command -v godot &> /dev/null; then
+        echo "godot"
+        return 0
+    fi
+
+    # Check common installation locations on macOS
+    if [ -d "/Applications/Godot_mono.app" ]; then
+        echo "/Applications/Godot_mono.app/Contents/MacOS/Godot"
+        return 0
+    fi
+
+    if [ -d "/Applications/Godot.app" ]; then
+        echo "/Applications/Godot.app/Contents/MacOS/Godot"
+        return 0
+    fi
+
+    # Check for Godot in the current directory
+    if [ -f "./Godot" ]; then
+        echo "./Godot"
+        return 0
+    fi
+
+    # Godot not found
+    return 1
+}
+
+# Find Godot executable
+GODOT_EXECUTABLE=$(find_godot)
+
+# Check if Godot was found
+if [ -z "$GODOT_EXECUTABLE" ]; then
+    echo "Error: Godot executable not found"
+    echo "Please install Godot from https://godotengine.org/download"
+    echo "or specify the path to the Godot executable in the GODOT_EXECUTABLE environment variable"
+    echo "Example: GODOT_EXECUTABLE=/path/to/godot ./run_pixel_drawing_demo.sh"
+    exit 1
+fi
+
+echo "Using Godot executable: $GODOT_EXECUTABLE"
+
+# Get the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo "Running Pixel Drawing Demo scene..."
+echo "Project path: $DIR"
+
+# Run the scene
+cd "$DIR"
+"$GODOT_EXECUTABLE" --path . --scene Scenes/PixelDrawingDemo.tscn
+
+# Get the exit code
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "Scene ran successfully!"
+else
+    echo "Scene failed to run. See above for details."
+fi
+
+exit $EXIT_CODE

--- a/godot_project/run_pixel_visualization_sandbox.bat
+++ b/godot_project/run_pixel_visualization_sandbox.bat
@@ -1,0 +1,35 @@
+@echo off
+REM This script runs the Pixel Visualization Sandbox scene
+
+REM Find the Godot executable
+set "GODOT_EXECUTABLE=C:\Godot_v4.4.1-stable_mono_win64\Godot_v4.4.1-stable_mono_win64\Godot_v4.4.1-stable_mono_win64_console.exe"
+
+REM Check if Godot executable exists
+if not exist "%GODOT_EXECUTABLE%" (
+    echo Godot executable not found at %GODOT_EXECUTABLE%
+    echo Please install Godot or update the script with the correct path.
+    exit /b 1
+)
+
+echo Using Godot executable: %GODOT_EXECUTABLE%
+
+REM Get the directory of this script
+set "DIR=%~dp0"
+
+echo Running Pixel Visualization Sandbox scene...
+echo Project path: %DIR%
+
+REM Run the scene
+cd "%DIR%"
+"%GODOT_EXECUTABLE%" --path . --scene Scenes/PixelVisualizationSandbox.tscn
+
+REM Get the exit code
+set EXIT_CODE=%ERRORLEVEL%
+
+if %EXIT_CODE% equ 0 (
+    echo Scene ran successfully!
+) else (
+    echo Scene failed to run. See above for details.
+)
+
+exit /b %EXIT_CODE%

--- a/godot_project/run_pixel_visualization_sandbox.sh
+++ b/godot_project/run_pixel_visualization_sandbox.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# This script runs the Pixel Visualization Sandbox scene
+
+# Function to find Godot executable
+find_godot() {
+    # Check if GODOT_EXECUTABLE environment variable is set
+    if [ ! -z "$GODOT_EXECUTABLE" ]; then
+        if [ -f "$GODOT_EXECUTABLE" ]; then
+            echo "$GODOT_EXECUTABLE"
+            return 0
+        else
+            echo "Warning: GODOT_EXECUTABLE is set but the file does not exist: $GODOT_EXECUTABLE"
+        fi
+    fi
+
+    # Check if Godot is in PATH
+    if command -v godot &> /dev/null; then
+        echo "godot"
+        return 0
+    fi
+
+    # Check common installation locations on macOS
+    if [ -d "/Applications/Godot_mono.app" ]; then
+        echo "/Applications/Godot_mono.app/Contents/MacOS/Godot"
+        return 0
+    fi
+
+    if [ -d "/Applications/Godot.app" ]; then
+        echo "/Applications/Godot.app/Contents/MacOS/Godot"
+        return 0
+    fi
+
+    # Check for Godot in the current directory
+    if [ -f "./Godot" ]; then
+        echo "./Godot"
+        return 0
+    fi
+
+    # Godot not found
+    return 1
+}
+
+# Find Godot executable
+GODOT_EXECUTABLE=$(find_godot)
+
+# Check if Godot was found
+if [ -z "$GODOT_EXECUTABLE" ]; then
+    echo "Error: Godot executable not found"
+    echo "Please install Godot from https://godotengine.org/download"
+    echo "or specify the path to the Godot executable in the GODOT_EXECUTABLE environment variable"
+    echo "Example: GODOT_EXECUTABLE=/path/to/godot ./run_pixel_visualization_sandbox.sh"
+    exit 1
+fi
+
+echo "Using Godot executable: $GODOT_EXECUTABLE"
+
+# Get the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo "Running Pixel Visualization Sandbox scene..."
+echo "Project path: $DIR"
+
+# Run the scene
+cd "$DIR"
+"$GODOT_EXECUTABLE" --path . --scene Scenes/PixelVisualizationSandbox.tscn
+
+# Get the exit code
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "Scene ran successfully!"
+else
+    echo "Scene failed to run. See above for details."
+fi
+
+exit $EXIT_CODE

--- a/godot_project/scripts/PixelDrawingDemo.cs
+++ b/godot_project/scripts/PixelDrawingDemo.cs
@@ -1,0 +1,382 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+
+namespace SignalLost
+{
+    /// <summary>
+    /// A simple demo for visualizing pixel-based drawing.
+    /// </summary>
+    public partial class PixelDrawingDemo : Control
+    {
+        // Configuration
+        [Export] public int GridSize { get; set; } = 8;
+        [Export] public Color GridColor { get; set; } = new Color(0.3f, 0.3f, 0.3f, 0.3f);
+        [Export] public Color ActivePixelColor { get; set; } = new Color(0.0f, 0.8f, 0.0f, 1.0f);
+        [Export] public Color BackgroundColor { get; set; } = new Color(0.1f, 0.1f, 0.1f, 1.0f);
+        
+        // State
+        private bool[,] _pixels;
+        private int _gridWidth;
+        private int _gridHeight;
+        private bool _isDrawing = false;
+        private bool _isErasing = false;
+        private Vector2I _lastPixelPos = new Vector2I(-1, -1);
+        private List<Vector2I> _currentStroke = new List<Vector2I>();
+        
+        // UI Elements
+        private Button _clearButton;
+        private Button _saveButton;
+        private Button _loadButton;
+        private Label _infoLabel;
+        private SpinBox _gridSizeSpinBox;
+        private ColorPickerButton _pixelColorPicker;
+        
+        // Called when the node enters the scene tree
+        public override void _Ready()
+        {
+            // Get references to UI elements
+            _clearButton = GetNode<Button>("ControlPanel/ClearButton");
+            _saveButton = GetNode<Button>("ControlPanel/SaveButton");
+            _loadButton = GetNode<Button>("ControlPanel/LoadButton");
+            _infoLabel = GetNode<Label>("ControlPanel/InfoLabel");
+            _gridSizeSpinBox = GetNode<SpinBox>("ControlPanel/GridSizeSpinBox");
+            _pixelColorPicker = GetNode<ColorPickerButton>("ControlPanel/PixelColorPicker");
+            
+            // Connect signals
+            _clearButton.Pressed += OnClearButtonPressed;
+            _saveButton.Pressed += OnSaveButtonPressed;
+            _loadButton.Pressed += OnLoadButtonPressed;
+            _gridSizeSpinBox.ValueChanged += OnGridSizeChanged;
+            _pixelColorPicker.ColorChanged += OnPixelColorChanged;
+            
+            // Initialize UI
+            _gridSizeSpinBox.Value = GridSize;
+            _pixelColorPicker.Color = ActivePixelColor;
+            
+            // Initialize the pixel grid
+            InitializeGrid();
+            
+            // Update info
+            UpdateInfoLabel();
+        }
+        
+        // Initialize the pixel grid
+        private void InitializeGrid()
+        {
+            Vector2 size = GetViewportRect().Size;
+            _gridWidth = (int)(size.X * 0.7f) / GridSize;
+            _gridHeight = (int)(size.Y) / GridSize;
+            
+            _pixels = new bool[_gridWidth, _gridHeight];
+            
+            // Clear all pixels
+            for (int x = 0; x < _gridWidth; x++)
+            {
+                for (int y = 0; y < _gridHeight; y++)
+                {
+                    _pixels[x, y] = false;
+                }
+            }
+            
+            // Queue redraw
+            QueueRedraw();
+        }
+        
+        // Update the info label
+        private void UpdateInfoLabel()
+        {
+            int activePixels = CountActivePixels();
+            float percentage = (float)activePixels / (_gridWidth * _gridHeight) * 100;
+            
+            _infoLabel.Text = $"Grid Size: {GridSize}px\n" +
+                             $"Grid Dimensions: {_gridWidth} x {_gridHeight}\n" +
+                             $"Active Pixels: {activePixels} ({percentage:F2}%)\n\n" +
+                             "Left-click to draw\n" +
+                             "Right-click to erase\n" +
+                             "Shift+click to draw lines";
+        }
+        
+        // Count active pixels
+        private int CountActivePixels()
+        {
+            int count = 0;
+            
+            for (int x = 0; x < _gridWidth; x++)
+            {
+                for (int y = 0; y < _gridHeight; y++)
+                {
+                    if (_pixels[x, y])
+                    {
+                        count++;
+                    }
+                }
+            }
+            
+            return count;
+        }
+        
+        // Handle input events
+        public override void _Input(InputEvent @event)
+        {
+            if (@event is InputEventMouseButton mouseButtonEvent)
+            {
+                if (mouseButtonEvent.ButtonIndex == MouseButton.Left)
+                {
+                    _isDrawing = mouseButtonEvent.Pressed;
+                    _isErasing = false;
+                    
+                    if (_isDrawing)
+                    {
+                        Vector2I pixelPos = GetPixelPos(mouseButtonEvent.Position);
+                        if (IsValidPixelPos(pixelPos))
+                        {
+                            _lastPixelPos = pixelPos;
+                            _currentStroke.Clear();
+                            _currentStroke.Add(pixelPos);
+                            SetPixel(pixelPos.X, pixelPos.Y, true);
+                        }
+                    }
+                    else
+                    {
+                        _lastPixelPos = new Vector2I(-1, -1);
+                    }
+                }
+                else if (mouseButtonEvent.ButtonIndex == MouseButton.Right)
+                {
+                    _isErasing = mouseButtonEvent.Pressed;
+                    _isDrawing = false;
+                    
+                    if (_isErasing)
+                    {
+                        Vector2I pixelPos = GetPixelPos(mouseButtonEvent.Position);
+                        if (IsValidPixelPos(pixelPos))
+                        {
+                            _lastPixelPos = pixelPos;
+                            SetPixel(pixelPos.X, pixelPos.Y, false);
+                        }
+                    }
+                    else
+                    {
+                        _lastPixelPos = new Vector2I(-1, -1);
+                    }
+                }
+            }
+            else if (@event is InputEventMouseMotion mouseMotionEvent && (_isDrawing || _isErasing))
+            {
+                Vector2I pixelPos = GetPixelPos(mouseMotionEvent.Position);
+                if (IsValidPixelPos(pixelPos) && pixelPos != _lastPixelPos)
+                {
+                    if (Input.IsKeyPressed(Key.Shift) && _lastPixelPos.X >= 0 && _lastPixelPos.Y >= 0)
+                    {
+                        // Draw a line from last position to current position
+                        DrawLine(_lastPixelPos, pixelPos, _isDrawing);
+                    }
+                    else
+                    {
+                        // Just set the current pixel
+                        SetPixel(pixelPos.X, pixelPos.Y, _isDrawing);
+                    }
+                    
+                    _lastPixelPos = pixelPos;
+                    if (_isDrawing)
+                    {
+                        _currentStroke.Add(pixelPos);
+                    }
+                }
+            }
+        }
+        
+        // Draw a line between two pixel positions
+        private void DrawLine(Vector2I from, Vector2I to, bool value)
+        {
+            // Bresenham's line algorithm
+            int dx = Math.Abs(to.X - from.X);
+            int dy = Math.Abs(to.Y - from.Y);
+            int sx = from.X < to.X ? 1 : -1;
+            int sy = from.Y < to.Y ? 1 : -1;
+            int err = dx - dy;
+            
+            while (true)
+            {
+                SetPixel(from.X, from.Y, value);
+                if (_isDrawing)
+                {
+                    _currentStroke.Add(from);
+                }
+                
+                if (from.X == to.X && from.Y == to.Y)
+                    break;
+                
+                int e2 = 2 * err;
+                if (e2 > -dy)
+                {
+                    err -= dy;
+                    from.X += sx;
+                }
+                
+                if (e2 < dx)
+                {
+                    err += dx;
+                    from.Y += sy;
+                }
+            }
+        }
+        
+        // Convert screen position to pixel grid position
+        private Vector2I GetPixelPos(Vector2 screenPos)
+        {
+            int x = (int)(screenPos.X / GridSize);
+            int y = (int)(screenPos.Y / GridSize);
+            return new Vector2I(x, y);
+        }
+        
+        // Check if a pixel position is valid
+        private bool IsValidPixelPos(Vector2I pos)
+        {
+            return pos.X >= 0 && pos.X < _gridWidth && pos.Y >= 0 && pos.Y < _gridHeight;
+        }
+        
+        // Set a pixel value
+        private void SetPixel(int x, int y, bool value)
+        {
+            if (x >= 0 && x < _gridWidth && y >= 0 && y < _gridHeight)
+            {
+                _pixels[x, y] = value;
+                QueueRedraw();
+                UpdateInfoLabel();
+            }
+        }
+        
+        // Draw function
+        public override void _Draw()
+        {
+            // Draw background
+            DrawRect(new Rect2(0, 0, _gridWidth * GridSize, _gridHeight * GridSize), BackgroundColor);
+            
+            // Draw grid
+            for (int x = 0; x <= _gridWidth; x++)
+            {
+                DrawLine(new Vector2(x * GridSize, 0), new Vector2(x * GridSize, _gridHeight * GridSize), GridColor);
+            }
+            
+            for (int y = 0; y <= _gridHeight; y++)
+            {
+                DrawLine(new Vector2(0, y * GridSize), new Vector2(_gridWidth * GridSize, y * GridSize), GridColor);
+            }
+            
+            // Draw active pixels
+            for (int x = 0; x < _gridWidth; x++)
+            {
+                for (int y = 0; y < _gridHeight; y++)
+                {
+                    if (_pixels[x, y])
+                    {
+                        DrawRect(new Rect2(x * GridSize, y * GridSize, GridSize, GridSize), ActivePixelColor);
+                    }
+                }
+            }
+        }
+        
+        // Handle resize
+        public override void _Notification(int what)
+        {
+            if (what == NotificationResized)
+            {
+                InitializeGrid();
+            }
+        }
+        
+        // Event handlers
+        private void OnClearButtonPressed()
+        {
+            for (int x = 0; x < _gridWidth; x++)
+            {
+                for (int y = 0; y < _gridHeight; y++)
+                {
+                    _pixels[x, y] = false;
+                }
+            }
+            
+            QueueRedraw();
+            UpdateInfoLabel();
+        }
+        
+        private void OnSaveButtonPressed()
+        {
+            // Convert pixel data to a string representation
+            string data = "";
+            
+            for (int y = 0; y < _gridHeight; y++)
+            {
+                for (int x = 0; x < _gridWidth; x++)
+                {
+                    data += _pixels[x, y] ? "1" : "0";
+                }
+                data += "\n";
+            }
+            
+            // Save to a file
+            string path = "user://pixel_drawing.txt";
+            using var file = FileAccess.Open(path, FileAccess.ModeFlags.Write);
+            if (file != null)
+            {
+                file.StoreString(data);
+                GD.Print($"Pixel data saved to {path}");
+                _infoLabel.Text = $"Pixel data saved to {path}\n\n" + _infoLabel.Text;
+            }
+            else
+            {
+                GD.PrintErr($"Failed to save pixel data to {path}");
+                _infoLabel.Text = $"Failed to save pixel data\n\n" + _infoLabel.Text;
+            }
+        }
+        
+        private void OnLoadButtonPressed()
+        {
+            // Load from a file
+            string path = "user://pixel_drawing.txt";
+            using var file = FileAccess.Open(path, FileAccess.ModeFlags.Read);
+            if (file != null)
+            {
+                string data = file.GetAsText();
+                string[] lines = data.Split('\n');
+                
+                // Clear current pixels
+                OnClearButtonPressed();
+                
+                // Parse the data
+                for (int y = 0; y < Math.Min(lines.Length, _gridHeight); y++)
+                {
+                    string line = lines[y];
+                    for (int x = 0; x < Math.Min(line.Length, _gridWidth); x++)
+                    {
+                        _pixels[x, y] = line[x] == '1';
+                    }
+                }
+                
+                GD.Print($"Pixel data loaded from {path}");
+                _infoLabel.Text = $"Pixel data loaded from {path}\n\n" + _infoLabel.Text;
+                QueueRedraw();
+                UpdateInfoLabel();
+            }
+            else
+            {
+                GD.PrintErr($"Failed to load pixel data from {path}");
+                _infoLabel.Text = $"Failed to load pixel data\n\n" + _infoLabel.Text;
+            }
+        }
+        
+        private void OnGridSizeChanged(double value)
+        {
+            GridSize = (int)value;
+            InitializeGrid();
+        }
+        
+        private void OnPixelColorChanged(Color color)
+        {
+            ActivePixelColor = color;
+            QueueRedraw();
+        }
+    }
+}

--- a/godot_project/scripts/PixelVisualizationSandbox.cs
+++ b/godot_project/scripts/PixelVisualizationSandbox.cs
@@ -1,0 +1,295 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+using SignalLost.Utils;
+
+namespace SignalLost
+{
+    /// <summary>
+    /// A sandbox for visualizing and testing pixel-based rendering.
+    /// </summary>
+    public partial class PixelVisualizationSandbox : Control
+    {
+        // References to UI elements
+        private PixelMessageDisplay _messageDisplay;
+        private ScreenshotTaker _screenshotTaker;
+        private Label _debugInfoLabel;
+        private Button _takeScreenshotButton;
+        private Button _toggleGridButton;
+        private Button _toggleAsciiArtButton;
+        private HSlider _interferenceSlider;
+        private OptionButton _messageTypeDropdown;
+        private TextEdit _contentInput;
+        private TextEdit _asciiArtInput;
+        private CheckBox _enableScanlinesCheckbox;
+        private CheckBox _enableFlickerCheckbox;
+        private CheckBox _enableTypewriterSoundCheckbox;
+        private SpinBox _characterSizeSpinBox;
+        private ColorPickerButton _textColorPicker;
+        private ColorPickerButton _bgColorPicker;
+
+        // State
+        private bool _showGrid = false;
+        private bool _showAsciiArt = false;
+        private List<string> _asciiArt = new List<string>();
+
+        // Called when the node enters the scene tree
+        public override void _Ready()
+        {
+            // Get references to UI elements
+            _messageDisplay = GetNode<PixelMessageDisplay>("PixelMessageDisplay");
+            _screenshotTaker = GetNode<ScreenshotTaker>("ScreenshotTaker");
+            _debugInfoLabel = GetNode<Label>("ControlPanel/DebugInfo");
+            _takeScreenshotButton = GetNode<Button>("ControlPanel/ScreenshotButton");
+            _toggleGridButton = GetNode<Button>("ControlPanel/ToggleGridButton");
+            _toggleAsciiArtButton = GetNode<Button>("ControlPanel/ToggleAsciiArtButton");
+            _interferenceSlider = GetNode<HSlider>("ControlPanel/InterferenceSlider");
+            _messageTypeDropdown = GetNode<OptionButton>("ControlPanel/MessageTypeDropdown");
+            _contentInput = GetNode<TextEdit>("ControlPanel/ContentInput");
+            _asciiArtInput = GetNode<TextEdit>("ControlPanel/AsciiArtInput");
+            _enableScanlinesCheckbox = GetNode<CheckBox>("ControlPanel/EnableScanlinesCheckbox");
+            _enableFlickerCheckbox = GetNode<CheckBox>("ControlPanel/EnableFlickerCheckbox");
+            _enableTypewriterSoundCheckbox = GetNode<CheckBox>("ControlPanel/EnableTypewriterSoundCheckbox");
+            _characterSizeSpinBox = GetNode<SpinBox>("ControlPanel/CharacterSizeSpinBox");
+            _textColorPicker = GetNode<ColorPickerButton>("ControlPanel/TextColorPicker");
+            _bgColorPicker = GetNode<ColorPickerButton>("ControlPanel/BgColorPicker");
+
+            // Connect signals
+            _takeScreenshotButton.Pressed += OnTakeScreenshotPressed;
+            _toggleGridButton.Pressed += OnToggleGridPressed;
+            _toggleAsciiArtButton.Pressed += OnToggleAsciiArtPressed;
+            _interferenceSlider.ValueChanged += OnInterferenceChanged;
+            _messageTypeDropdown.ItemSelected += OnMessageTypeSelected;
+            _contentInput.TextChanged += OnContentChanged;
+            _asciiArtInput.TextChanged += OnAsciiArtChanged;
+            _enableScanlinesCheckbox.Toggled += OnScanlinesToggled;
+            _enableFlickerCheckbox.Toggled += OnFlickerToggled;
+            _enableTypewriterSoundCheckbox.Toggled += OnTypewriterSoundToggled;
+            _characterSizeSpinBox.ValueChanged += OnCharacterSizeChanged;
+            _textColorPicker.ColorChanged += OnTextColorChanged;
+            _bgColorPicker.ColorChanged += OnBgColorChanged;
+
+            // Initialize UI state
+            InitializeUI();
+
+            // Set initial message
+            UpdateMessage();
+        }
+
+        // Initialize UI elements with default values
+        private void InitializeUI()
+        {
+            // Set up message type dropdown
+            _messageTypeDropdown.Clear();
+            _messageTypeDropdown.AddItem("Terminal");
+            _messageTypeDropdown.AddItem("Radio");
+            _messageTypeDropdown.AddItem("Note");
+            _messageTypeDropdown.AddItem("Computer");
+            _messageTypeDropdown.Selected = 0;
+
+            // Set up interference slider
+            _interferenceSlider.MinValue = 0.0f;
+            _interferenceSlider.MaxValue = 1.0f;
+            _interferenceSlider.Step = 0.01f;
+            _interferenceSlider.Value = 0.2f;
+
+            // Set up checkboxes
+            _enableScanlinesCheckbox.ButtonPressed = _messageDisplay.EnableScanlines;
+            _enableFlickerCheckbox.ButtonPressed = _messageDisplay.EnableScreenFlicker;
+            _enableTypewriterSoundCheckbox.ButtonPressed = _messageDisplay.EnableTypewriterSound;
+
+            // Set up character size
+            _characterSizeSpinBox.MinValue = 4;
+            _characterSizeSpinBox.MaxValue = 16;
+            _characterSizeSpinBox.Step = 1;
+            _characterSizeSpinBox.Value = _messageDisplay.CharacterSize;
+
+            // Set up color pickers
+            _textColorPicker.Color = _messageDisplay.TextColor;
+            _bgColorPicker.Color = _messageDisplay.BackgroundColor;
+
+            // Set up content input
+            _contentInput.Text = "Welcome to the Pixel Visualization Sandbox!\n\nThis tool allows you to test and visualize the pixel-based rendering system.\n\nTry adjusting the parameters to see how they affect the display.";
+
+            // Set up ASCII art input
+            _asciiArtInput.Text = "  _____  _          _ \n" +
+                                 " |  __ \\(_)        | |\n" +
+                                 " | |__) |___  _____| |\n" +
+                                 " |  ___/| \\ \\/ / _ \\ |\n" +
+                                 " | |    | |>  <  __/ |\n" +
+                                 " |_|    |_/_/\\_\\___|_|";
+
+            // Hide ASCII art input initially
+            _asciiArtInput.Visible = false;
+            _toggleAsciiArtButton.Text = "Show ASCII Art";
+        }
+
+        // Update the message display with current settings
+        private void UpdateMessage()
+        {
+            // Get message type
+            string messageType = _messageTypeDropdown.GetItemText(_messageTypeDropdown.Selected);
+            _messageDisplay.MessageType = messageType;
+
+            // Get content
+            string content = _contentInput.Text;
+
+            // Get interference level
+            float interference = (float)_interferenceSlider.Value;
+
+            // Update message display settings
+            _messageDisplay.EnableScanlines = _enableScanlinesCheckbox.ButtonPressed;
+            _messageDisplay.EnableScreenFlicker = _enableFlickerCheckbox.ButtonPressed;
+            _messageDisplay.EnableTypewriterSound = _enableTypewriterSoundCheckbox.ButtonPressed;
+            _messageDisplay.CharacterSize = (int)_characterSizeSpinBox.Value;
+            _messageDisplay.TextColor = _textColorPicker.Color;
+            _messageDisplay.BackgroundColor = _bgColorPicker.Color;
+
+            // Set the message
+            if (_showAsciiArt)
+            {
+                // Parse ASCII art from input
+                _asciiArt = new List<string>(_asciiArtInput.Text.Split('\n'));
+                _messageDisplay.SetMessageWithArt("sandbox_message", "Pixel Visualization Sandbox", content, _asciiArt, true, interference);
+            }
+            else
+            {
+                _messageDisplay.SetMessage("sandbox_message", "Pixel Visualization Sandbox", content, true, interference);
+            }
+
+            // Make sure the message is visible
+            _messageDisplay.SetVisible(true);
+
+            // Update debug info
+            UpdateDebugInfo();
+        }
+
+        // Update the debug information display
+        private void UpdateDebugInfo()
+        {
+            string debugInfo = $"Message Type: {_messageDisplay.MessageType}\n" +
+                              $"Interference: {_interferenceSlider.Value:F2}\n" +
+                              $"Character Size: {_messageDisplay.CharacterSize}\n" +
+                              $"Scanlines: {_messageDisplay.EnableScanlines}\n" +
+                              $"Flicker: {_messageDisplay.EnableScreenFlicker}\n" +
+                              $"Typewriter Sound: {_messageDisplay.EnableTypewriterSound}\n" +
+                              $"ASCII Art: {_showAsciiArt}\n" +
+                              $"Grid: {_showGrid}";
+
+            _debugInfoLabel.Text = debugInfo;
+        }
+
+        // Draw function for custom rendering
+        public override void _Draw()
+        {
+            base._Draw();
+
+            // Draw grid if enabled
+            if (_showGrid)
+            {
+                DrawGrid();
+            }
+        }
+
+        // Draw a pixel grid
+        private void DrawGrid()
+        {
+            Vector2 size = Size;
+            int gridSize = _messageDisplay.CharacterSize;
+            Color gridColor = new Color(0.3f, 0.3f, 0.3f, 0.3f);
+
+            // Draw vertical lines
+            for (int x = 0; x < size.X; x += gridSize)
+            {
+                DrawLine(new Vector2(x, 0), new Vector2(x, size.Y), gridColor);
+            }
+
+            // Draw horizontal lines
+            for (int y = 0; y < size.Y; y += gridSize)
+            {
+                DrawLine(new Vector2(0, y), new Vector2(size.X, y), gridColor);
+            }
+        }
+
+        // Event handlers
+        private void OnTakeScreenshotPressed()
+        {
+            string screenshotPath = _screenshotTaker.TakeTimestampedScreenshot("pixel_sandbox");
+            GD.Print($"Screenshot saved to: {screenshotPath}");
+            _debugInfoLabel.Text = $"Screenshot saved to: {screenshotPath}\n\n{_debugInfoLabel.Text}";
+        }
+
+        private void OnToggleGridPressed()
+        {
+            _showGrid = !_showGrid;
+            _toggleGridButton.Text = _showGrid ? "Hide Grid" : "Show Grid";
+            QueueRedraw();
+            UpdateDebugInfo();
+        }
+
+        private void OnToggleAsciiArtPressed()
+        {
+            _showAsciiArt = !_showAsciiArt;
+            _toggleAsciiArtButton.Text = _showAsciiArt ? "Hide ASCII Art" : "Show ASCII Art";
+            _asciiArtInput.Visible = _showAsciiArt;
+            UpdateMessage();
+        }
+
+        private void OnInterferenceChanged(double value)
+        {
+            UpdateMessage();
+        }
+
+        private void OnMessageTypeSelected(long index)
+        {
+            UpdateMessage();
+        }
+
+        private void OnContentChanged()
+        {
+            UpdateMessage();
+        }
+
+        private void OnAsciiArtChanged()
+        {
+            if (_showAsciiArt)
+            {
+                UpdateMessage();
+            }
+        }
+
+        private void OnScanlinesToggled(bool toggled)
+        {
+            UpdateMessage();
+        }
+
+        private void OnFlickerToggled(bool toggled)
+        {
+            UpdateMessage();
+        }
+
+        private void OnTypewriterSoundToggled(bool toggled)
+        {
+            UpdateMessage();
+        }
+
+        private void OnCharacterSizeChanged(double value)
+        {
+            UpdateMessage();
+            if (_showGrid)
+            {
+                QueueRedraw();
+            }
+        }
+
+        private void OnTextColorChanged(Color color)
+        {
+            UpdateMessage();
+        }
+
+        private void OnBgColorChanged(Color color)
+        {
+            UpdateMessage();
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a pixel drawing demo and visualization sandbox to help with visual development. The tools provide a way to prototype and test pixel-based UI elements, game assets, and visual effects before implementing them in the actual game code.\n\n## Features\n\n- Pixel Drawing Demo: A grid-based tool for creating pixel art\n- Interactive controls for adjusting grid size and pixel color\n- Drawing and erasing functionality with line drawing support\n- Save/load functionality for pixel designs\n- Cross-platform support with scripts for Mac and Windows\n\nThese tools will help Agent Alpha develop visuals for the game more efficiently.