### PR TITLE
Add radio interface integration with game systems

### DIFF
--- a/pixel_drawing_screenshot.sh
+++ b/pixel_drawing_screenshot.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Take a screenshot of the pixel drawing demo
+/Applications/Godot_mono.app/Contents/MacOS/Godot --path . --script scripts/utils/TakeScreenshot.cs -- "pixel_drawing_$(date +%Y%m%d_%H%M%S)"
+
+echo "Screenshot saved to ~/Library/Application Support/Godot/app_userdata/Signal Lost/Screenshots/"
+echo "You can view the most recent screenshot with: open ~/Library/Application\ Support/Godot/app_userdata/Signal\ Lost/Screenshots/pixel_drawing_*.png"

--- a/run_pixel_radio_interface.sh
+++ b/run_pixel_radio_interface.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# This script runs the Pixel Radio Interface scene
+
+# Function to find Godot executable
+find_godot() {
+    # Check if GODOT_EXECUTABLE environment variable is set
+    if [ ! -z "$GODOT_EXECUTABLE" ]; then
+        if [ -f "$GODOT_EXECUTABLE" ]; then
+            echo "$GODOT_EXECUTABLE"
+            return 0
+        else
+            echo "Warning: GODOT_EXECUTABLE is set but the file does not exist: $GODOT_EXECUTABLE"
+        fi
+    fi
+
+    # Check if Godot is in PATH
+    if command -v godot &> /dev/null; then
+        echo "godot"
+        return 0
+    fi
+
+    # Check common installation locations on macOS
+    if [ -d "/Applications/Godot_mono.app" ]; then
+        echo "/Applications/Godot_mono.app/Contents/MacOS/Godot"
+        return 0
+    fi
+
+    if [ -d "/Applications/Godot.app" ]; then
+        echo "/Applications/Godot.app/Contents/MacOS/Godot"
+        return 0
+    fi
+
+    # Check for Godot in the current directory
+    if [ -f "./Godot" ]; then
+        echo "./Godot"
+        return 0
+    fi
+
+    # Godot not found
+    return 1
+}
+
+# Find Godot executable
+GODOT_EXECUTABLE=$(find_godot)
+
+# Check if Godot was found
+if [ -z "$GODOT_EXECUTABLE" ]; then
+    echo "Error: Godot executable not found"
+    echo "Please install Godot from https://godotengine.org/download"
+    echo "or specify the path to the Godot executable in the GODOT_EXECUTABLE environment variable"
+    echo "Example: GODOT_EXECUTABLE=/path/to/godot ./run_pixel_radio_interface.sh"
+    exit 1
+fi
+
+echo "Using Godot executable: $GODOT_EXECUTABLE"
+
+# Get the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo "Running Pixel Radio Interface scene..."
+echo "Project path: $DIR"
+
+# Run the scene
+cd "$DIR"
+"$GODOT_EXECUTABLE" --path . --scene Scenes/PixelRadioInterface.tscn
+
+# Get the exit code
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "Scene ran successfully!"
+else
+    echo "Scene failed to run. See above for details."
+fi
+
+exit $EXIT_CODE

--- a/run_radio_interface_demo.sh
+++ b/run_radio_interface_demo.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# This script runs the Radio Interface Demo scene
+
+# Function to find Godot executable
+find_godot() {
+    # Check if GODOT_EXECUTABLE environment variable is set
+    if [ ! -z "$GODOT_EXECUTABLE" ]; then
+        if [ -f "$GODOT_EXECUTABLE" ]; then
+            echo "$GODOT_EXECUTABLE"
+            return 0
+        else
+            echo "Warning: GODOT_EXECUTABLE is set but the file does not exist: $GODOT_EXECUTABLE"
+        fi
+    fi
+
+    # Check if Godot is in PATH
+    if command -v godot &> /dev/null; then
+        echo "godot"
+        return 0
+    fi
+
+    # Check common installation locations on macOS
+    if [ -d "/Applications/Godot_mono.app" ]; then
+        echo "/Applications/Godot_mono.app/Contents/MacOS/Godot"
+        return 0
+    fi
+
+    if [ -d "/Applications/Godot.app" ]; then
+        echo "/Applications/Godot.app/Contents/MacOS/Godot"
+        return 0
+    fi
+
+    # Check for Godot in the current directory
+    if [ -f "./Godot" ]; then
+        echo "./Godot"
+        return 0
+    fi
+
+    # Godot not found
+    return 1
+}
+
+# Find Godot executable
+GODOT_EXECUTABLE=$(find_godot)
+
+# Check if Godot was found
+if [ -z "$GODOT_EXECUTABLE" ]; then
+    echo "Error: Godot executable not found"
+    echo "Please install Godot from https://godotengine.org/download"
+    echo "or specify the path to the Godot executable in the GODOT_EXECUTABLE environment variable"
+    echo "Example: GODOT_EXECUTABLE=/path/to/godot ./run_radio_interface_demo.sh"
+    exit 1
+fi
+
+echo "Using Godot executable: $GODOT_EXECUTABLE"
+
+# Get the directory of this script
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+echo "Running Radio Interface Demo scene..."
+echo "Project path: $DIR"
+
+# Run the scene
+cd "$DIR"
+"$GODOT_EXECUTABLE" --path . --scene scenes/RadioInterfaceDemo.tscn
+
+# Get the exit code
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "Scene ran successfully!"
+else
+    echo "Scene failed to run. See above for details."
+fi
+
+exit $EXIT_CODE

--- a/scenes/PixelRadioInterface.tscn
+++ b/scenes/PixelRadioInterface.tscn
@@ -1,0 +1,12 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/PixelRadioInterface.cs" id="1_radio"]
+
+[node name="PixelRadioInterface" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_radio")

--- a/scenes/RadioInterfaceDemo.tscn
+++ b/scenes/RadioInterfaceDemo.tscn
@@ -1,0 +1,39 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/PixelRadioInterface.cs" id="1_radio"]
+[ext_resource type="Script" path="res://scripts/ui/RadioInterfaceManager.cs" id="2_manager"]
+[ext_resource type="Script" path="res://scripts/DemoInitializer.cs" id="3_init"]
+
+[node name="RadioInterfaceDemo" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("3_init")
+
+[node name="PixelRadioInterface" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_radio")
+
+[node name="RadioInterfaceManager" type="Node" parent="."]
+script = ExtResource("2_manager")
+RadioInterfacePath = NodePath("../PixelRadioInterface")
+
+[node name="Instructions" type="Label" parent="."]
+layout_mode = 0
+offset_left = 10.0
+offset_top = 10.0
+offset_right = 400.0
+offset_bottom = 100.0
+text = "Radio Interface Demo
+- Click the power button to turn the radio on/off
+- Drag the tuning dial to change frequency
+- Click the scan button to automatically find signals
+- Click the message button when lit to view messages"

--- a/scripts/DemoInitializer.cs
+++ b/scripts/DemoInitializer.cs
@@ -1,0 +1,140 @@
+using Godot;
+using System;
+using SignalLost;
+
+/// <summary>
+/// Initializes the demo environment for the radio interface.
+/// </summary>
+[GlobalClass]
+public partial class DemoInitializer : Control
+{
+    // Called when the node enters the scene tree
+    public override void _Ready()
+    {
+        // Check if GameState exists
+        var gameState = GetNode<GameState>("/root/GameState");
+        if (gameState == null)
+        {
+            // Create GameState
+            gameState = new GameState();
+            gameState.Name = "GameState";
+            GetTree().Root.AddChild(gameState);
+            GD.Print("DemoInitializer: Created GameState");
+        }
+        
+        // Check if RadioSystem exists
+        var radioSystem = GetNode<RadioSystem>("/root/RadioSystem");
+        if (radioSystem == null)
+        {
+            // Create RadioSystem
+            radioSystem = new RadioSystem();
+            radioSystem.Name = "RadioSystem";
+            GetTree().Root.AddChild(radioSystem);
+            GD.Print("DemoInitializer: Created RadioSystem");
+        }
+        
+        // Check if MessageManager exists
+        var messageManager = GetNode<MessageManager>("/root/MessageManager");
+        if (messageManager == null)
+        {
+            // Create MessageManager
+            messageManager = new MessageManager();
+            messageManager.Name = "MessageManager";
+            GetTree().Root.AddChild(messageManager);
+            GD.Print("DemoInitializer: Created MessageManager");
+        }
+        
+        // Initialize test signals and messages
+        InitializeTestData(gameState);
+        
+        GD.Print("DemoInitializer: Demo environment initialized");
+    }
+    
+    // Initialize test data for the demo
+    private void InitializeTestData(GameState gameState)
+    {
+        // Add test messages if they don't exist
+        if (!gameState.Messages.ContainsKey("msg_emergency"))
+        {
+            gameState.Messages["msg_emergency"] = new GameState.MessageData
+            {
+                Id = "msg_emergency",
+                Title = "EMERGENCY BROADCAST",
+                Content = "This is an emergency broadcast. All personnel must evacuate immediately. This is not a drill.",
+                Decoded = false
+            };
+        }
+        
+        if (!gameState.Messages.ContainsKey("msg_weather"))
+        {
+            gameState.Messages["msg_weather"] = new GameState.MessageData
+            {
+                Id = "msg_weather",
+                Title = "Weather Report",
+                Content = "Severe weather warning for the following areas: Sector 7, Sector 12, and Sector 15. Expect heavy precipitation and reduced visibility.",
+                Decoded = false
+            };
+        }
+        
+        if (!gameState.Messages.ContainsKey("msg_music"))
+        {
+            gameState.Messages["msg_music"] = new GameState.MessageData
+            {
+                Id = "msg_music",
+                Title = "Music Station",
+                Content = "You're listening to the wasteland's only music station. Up next: 'The End of the World' by Skeeter Davis.",
+                Decoded = true
+            };
+        }
+        
+        // Add test signals if they don't exist
+        bool hasEmergencySignal = false;
+        bool hasWeatherSignal = false;
+        bool hasMusicSignal = false;
+        
+        foreach (var signal in gameState.Signals)
+        {
+            if (signal.MessageId == "msg_emergency") hasEmergencySignal = true;
+            if (signal.MessageId == "msg_weather") hasWeatherSignal = true;
+            if (signal.MessageId == "msg_music") hasMusicSignal = true;
+        }
+        
+        if (!hasEmergencySignal)
+        {
+            gameState.Signals.Add(new GameState.SignalData
+            {
+                Id = "signal_emergency",
+                Frequency = 91.5f,
+                MessageId = "msg_emergency",
+                IsStatic = true,
+                Bandwidth = 0.3f
+            });
+        }
+        
+        if (!hasWeatherSignal)
+        {
+            gameState.Signals.Add(new GameState.SignalData
+            {
+                Id = "signal_weather",
+                Frequency = 95.7f,
+                MessageId = "msg_weather",
+                IsStatic = false,
+                Bandwidth = 0.2f
+            });
+        }
+        
+        if (!hasMusicSignal)
+        {
+            gameState.Signals.Add(new GameState.SignalData
+            {
+                Id = "signal_music",
+                Frequency = 103.2f,
+                MessageId = "msg_music",
+                IsStatic = true,
+                Bandwidth = 0.4f
+            });
+        }
+        
+        GD.Print("DemoInitializer: Test data initialized");
+    }
+}

--- a/scripts/ui/PixelRadioInterface.cs
+++ b/scripts/ui/PixelRadioInterface.cs
@@ -1,0 +1,410 @@
+using Godot;
+using System;
+
+namespace SignalLost.UI
+{
+    /// <summary>
+    /// A pixel-based radio interface for the Signal Lost game.
+    /// </summary>
+    [GlobalClass]
+    public partial class PixelRadioInterface : Control
+    {
+        // Configuration
+        [Export] public Color BackgroundColor { get; set; } = new Color(0.1f, 0.1f, 0.1f, 1.0f);
+        [Export] public Color BorderColor { get; set; } = new Color(0.3f, 0.3f, 0.3f, 1.0f);
+        [Export] public Color TextColor { get; set; } = new Color(0.0f, 0.8f, 0.0f, 1.0f);
+        [Export] public Color DialColor { get; set; } = new Color(0.7f, 0.7f, 0.7f, 1.0f);
+        [Export] public Color DialMarkerColor { get; set; } = new Color(0.9f, 0.1f, 0.1f, 1.0f);
+        [Export] public Color ButtonColor { get; set; } = new Color(0.5f, 0.5f, 0.5f, 1.0f);
+        [Export] public Color ButtonHighlightColor { get; set; } = new Color(0.7f, 0.7f, 0.7f, 1.0f);
+        [Export] public Color SignalMeterColor { get; set; } = new Color(0.0f, 0.8f, 0.0f, 1.0f);
+        [Export] public Color SignalMeterBackgroundColor { get; set; } = new Color(0.2f, 0.2f, 0.2f, 1.0f);
+        
+        // Radio state
+        [Export] public float MinFrequency { get; set; } = 88.0f;
+        [Export] public float MaxFrequency { get; set; } = 108.0f;
+        [Export] public float CurrentFrequency { get; set; } = 98.0f;
+        [Export] public float SignalStrength { get; set; } = 0.0f;
+        [Export] public bool IsPoweredOn { get; set; } = false;
+        
+        // UI elements
+        private Rect2 _tuningDialRect;
+        private Rect2 _frequencyDisplayRect;
+        private Rect2 _signalMeterRect;
+        private Rect2 _powerButtonRect;
+        private Rect2 _scanButtonRect;
+        private Rect2 _messageButtonRect;
+        
+        // Interaction state
+        private bool _isDraggingDial = false;
+        private Vector2 _lastMousePosition;
+        private float _dialRotation = 0.0f;
+        private bool _powerButtonHovered = false;
+        private bool _scanButtonHovered = false;
+        private bool _messageButtonHovered = false;
+        private bool _messageAvailable = false;
+        
+        // Signals
+        [Signal] public delegate void FrequencyChangedEventHandler(float frequency);
+        [Signal] public delegate void PowerToggleEventHandler(bool isPoweredOn);
+        [Signal] public delegate void ScanRequestedEventHandler();
+        [Signal] public delegate void MessageRequestedEventHandler();
+        
+        // Called when the node enters the scene tree
+        public override void _Ready()
+        {
+            // Initialize UI elements
+            UpdateUIRects();
+        }
+        
+        // Update UI element rectangles based on current size
+        private void UpdateUIRects()
+        {
+            Vector2 size = Size;
+            float width = size.X;
+            float height = size.Y;
+            
+            // Calculate radio panel dimensions
+            float panelWidth = width * 0.9f;
+            float panelHeight = height * 0.8f;
+            float panelX = (width - panelWidth) / 2;
+            float panelY = (height - panelHeight) / 2;
+            
+            // Tuning dial (circular)
+            float dialSize = Mathf.Min(panelWidth, panelHeight) * 0.4f;
+            float dialX = panelX + panelWidth * 0.25f - dialSize / 2;
+            float dialY = panelY + panelHeight * 0.5f - dialSize / 2;
+            _tuningDialRect = new Rect2(dialX, dialY, dialSize, dialSize);
+            
+            // Frequency display
+            float displayWidth = panelWidth * 0.4f;
+            float displayHeight = panelHeight * 0.15f;
+            float displayX = panelX + panelWidth * 0.55f;
+            float displayY = panelY + panelHeight * 0.3f;
+            _frequencyDisplayRect = new Rect2(displayX, displayY, displayWidth, displayHeight);
+            
+            // Signal meter
+            float meterWidth = panelWidth * 0.4f;
+            float meterHeight = panelHeight * 0.1f;
+            float meterX = panelX + panelWidth * 0.55f;
+            float meterY = panelY + panelHeight * 0.5f;
+            _signalMeterRect = new Rect2(meterX, meterY, meterWidth, meterHeight);
+            
+            // Power button
+            float buttonSize = panelHeight * 0.15f;
+            float powerX = panelX + panelWidth * 0.55f;
+            float powerY = panelY + panelHeight * 0.7f;
+            _powerButtonRect = new Rect2(powerX, powerY, buttonSize, buttonSize);
+            
+            // Scan button
+            float scanX = panelX + panelWidth * 0.7f;
+            float scanY = panelY + panelHeight * 0.7f;
+            _scanButtonRect = new Rect2(scanX, scanY, buttonSize, buttonSize);
+            
+            // Message button
+            float messageX = panelX + panelWidth * 0.85f;
+            float messageY = panelY + panelHeight * 0.7f;
+            _messageButtonRect = new Rect2(messageX, messageY, buttonSize, buttonSize);
+        }
+        
+        // Handle input events
+        public override void _Input(InputEvent @event)
+        {
+            if (@event is InputEventMouseButton mouseButtonEvent)
+            {
+                if (mouseButtonEvent.ButtonIndex == MouseButton.Left)
+                {
+                    Vector2 mousePos = mouseButtonEvent.Position;
+                    
+                    if (mouseButtonEvent.Pressed)
+                    {
+                        // Check if clicking on tuning dial
+                        if (_tuningDialRect.HasPoint(mousePos))
+                        {
+                            _isDraggingDial = true;
+                            _lastMousePosition = mousePos;
+                        }
+                        // Check if clicking on power button
+                        else if (_powerButtonRect.HasPoint(mousePos))
+                        {
+                            IsPoweredOn = !IsPoweredOn;
+                            EmitSignal(SignalName.PowerToggle, IsPoweredOn);
+                            QueueRedraw();
+                        }
+                        // Check if clicking on scan button
+                        else if (_scanButtonRect.HasPoint(mousePos) && IsPoweredOn)
+                        {
+                            EmitSignal(SignalName.ScanRequested);
+                            QueueRedraw();
+                        }
+                        // Check if clicking on message button
+                        else if (_messageButtonRect.HasPoint(mousePos) && IsPoweredOn && _messageAvailable)
+                        {
+                            EmitSignal(SignalName.MessageRequested);
+                            QueueRedraw();
+                        }
+                    }
+                    else
+                    {
+                        _isDraggingDial = false;
+                    }
+                }
+            }
+            else if (@event is InputEventMouseMotion mouseMotionEvent && _isDraggingDial && IsPoweredOn)
+            {
+                // Calculate dial rotation based on mouse movement
+                Vector2 center = new Vector2(_tuningDialRect.Position.X + _tuningDialRect.Size.X / 2, 
+                                           _tuningDialRect.Position.Y + _tuningDialRect.Size.Y / 2);
+                
+                Vector2 prevDirection = (_lastMousePosition - center).Normalized();
+                Vector2 newDirection = (mouseMotionEvent.Position - center).Normalized();
+                
+                // Calculate angle between previous and new direction
+                float angle = Mathf.Atan2(prevDirection.Cross(newDirection), prevDirection.Dot(newDirection));
+                
+                // Update dial rotation
+                _dialRotation += angle;
+                _dialRotation = Mathf.Wrap(_dialRotation, 0, Mathf.Pi * 2);
+                
+                // Update frequency based on dial rotation
+                float frequencyRange = MaxFrequency - MinFrequency;
+                float normalizedRotation = _dialRotation / (Mathf.Pi * 2);
+                CurrentFrequency = MinFrequency + normalizedRotation * frequencyRange;
+                
+                // Clamp frequency to valid range
+                CurrentFrequency = Mathf.Clamp(CurrentFrequency, MinFrequency, MaxFrequency);
+                
+                // Emit signal
+                EmitSignal(SignalName.FrequencyChanged, CurrentFrequency);
+                
+                // Update last mouse position
+                _lastMousePosition = mouseMotionEvent.Position;
+                
+                // Redraw
+                QueueRedraw();
+            }
+            else if (@event is InputEventMouseMotion mouseMotion)
+            {
+                // Update hover states
+                Vector2 mousePos = mouseMotion.Position;
+                _powerButtonHovered = _powerButtonRect.HasPoint(mousePos);
+                _scanButtonHovered = _scanButtonRect.HasPoint(mousePos) && IsPoweredOn;
+                _messageButtonHovered = _messageButtonRect.HasPoint(mousePos) && IsPoweredOn && _messageAvailable;
+                
+                // Redraw if hover state changed
+                QueueRedraw();
+            }
+        }
+        
+        // Draw the radio interface
+        public override void _Draw()
+        {
+            Vector2 size = Size;
+            
+            // Draw radio panel background
+            float panelWidth = size.X * 0.9f;
+            float panelHeight = size.Y * 0.8f;
+            float panelX = (size.X - panelWidth) / 2;
+            float panelY = (size.Y - panelHeight) / 2;
+            
+            DrawRect(new Rect2(panelX, panelY, panelWidth, panelHeight), BackgroundColor);
+            DrawRect(new Rect2(panelX, panelY, panelWidth, panelHeight), BorderColor, false, 2);
+            
+            // Draw radio title
+            DrawString(ThemeDB.FallbackFont, new Vector2(size.X / 2, panelY + 30), 
+                      "SIGNAL LOST RADIO", HorizontalAlignment.Center, -1, 20, TextColor);
+            
+            // Draw frequency display
+            Color displayColor = IsPoweredOn ? TextColor : new Color(TextColor, 0.3f);
+            DrawRect(_frequencyDisplayRect, new Color(0.0f, 0.0f, 0.0f, 1.0f));
+            DrawRect(_frequencyDisplayRect, BorderColor, false, 1);
+            
+            string frequencyText = IsPoweredOn ? $"{CurrentFrequency:F1} MHz" : "-- . - MHz";
+            DrawString(ThemeDB.FallbackFont, 
+                      new Vector2(_frequencyDisplayRect.Position.X + _frequencyDisplayRect.Size.X / 2, 
+                                 _frequencyDisplayRect.Position.Y + _frequencyDisplayRect.Size.Y / 2 + 8), 
+                      frequencyText, HorizontalAlignment.Center, -1, 18, displayColor);
+            
+            // Draw signal meter
+            DrawRect(_signalMeterRect, SignalMeterBackgroundColor);
+            DrawRect(_signalMeterRect, BorderColor, false, 1);
+            
+            if (IsPoweredOn)
+            {
+                float meterFill = _signalMeterRect.Size.X * SignalStrength;
+                DrawRect(new Rect2(_signalMeterRect.Position.X, _signalMeterRect.Position.Y, 
+                                  meterFill, _signalMeterRect.Size.Y), 
+                        SignalMeterColor);
+            }
+            
+            DrawString(ThemeDB.FallbackFont, 
+                      new Vector2(_signalMeterRect.Position.X + _signalMeterRect.Size.X / 2, 
+                                 _signalMeterRect.Position.Y - 10), 
+                      "SIGNAL", HorizontalAlignment.Center, -1, 14, TextColor);
+            
+            // Draw tuning dial
+            Vector2 dialCenter = new Vector2(_tuningDialRect.Position.X + _tuningDialRect.Size.X / 2, 
+                                           _tuningDialRect.Position.Y + _tuningDialRect.Size.Y / 2);
+            float dialRadius = _tuningDialRect.Size.X / 2;
+            
+            // Draw dial background
+            DrawCircle(dialCenter, dialRadius, new Color(0.2f, 0.2f, 0.2f, 1.0f));
+            DrawArc(dialCenter, dialRadius, 0, Mathf.Pi * 2, 32, BorderColor, 2);
+            
+            // Draw dial
+            Color actualDialColor = IsPoweredOn ? DialColor : new Color(DialColor, 0.5f);
+            DrawCircle(dialCenter, dialRadius * 0.8f, actualDialColor);
+            
+            // Draw dial marker
+            if (IsPoweredOn)
+            {
+                Vector2 markerDirection = Vector2.Right.Rotated(_dialRotation);
+                Vector2 markerStart = dialCenter + markerDirection * (dialRadius * 0.4f);
+                Vector2 markerEnd = dialCenter + markerDirection * (dialRadius * 0.7f);
+                DrawLine(markerStart, markerEnd, DialMarkerColor, 3);
+            }
+            
+            // Draw frequency ticks around the dial
+            for (int i = 0; i < 10; i++)
+            {
+                float angle = i * Mathf.Pi * 2 / 10;
+                Vector2 tickDirection = Vector2.Right.Rotated(angle);
+                Vector2 tickStart = dialCenter + tickDirection * (dialRadius * 0.8f);
+                Vector2 tickEnd = dialCenter + tickDirection * dialRadius;
+                DrawLine(tickStart, tickEnd, BorderColor, 1);
+                
+                // Draw frequency labels
+                float freq = MinFrequency + (MaxFrequency - MinFrequency) * (i / 10.0f);
+                Vector2 labelPos = dialCenter + tickDirection * (dialRadius * 1.2f);
+                DrawString(ThemeDB.FallbackFont, labelPos, $"{freq:F0}", HorizontalAlignment.Center, -1, 12, TextColor);
+            }
+            
+            DrawString(ThemeDB.FallbackFont, 
+                      new Vector2(dialCenter.X, _tuningDialRect.Position.Y - 10), 
+                      "TUNE", HorizontalAlignment.Center, -1, 14, TextColor);
+            
+            // Draw power button
+            Color powerBgColor = _powerButtonHovered ? ButtonHighlightColor : ButtonColor;
+            DrawCircle(new Vector2(_powerButtonRect.Position.X + _powerButtonRect.Size.X / 2, 
+                                  _powerButtonRect.Position.Y + _powerButtonRect.Size.Y / 2), 
+                      _powerButtonRect.Size.X / 2, powerBgColor);
+            
+            // Draw power symbol
+            Vector2 powerCenter = new Vector2(_powerButtonRect.Position.X + _powerButtonRect.Size.X / 2, 
+                                            _powerButtonRect.Position.Y + _powerButtonRect.Size.Y / 2);
+            float powerSymbolRadius = _powerButtonRect.Size.X * 0.3f;
+            DrawArc(powerCenter, powerSymbolRadius, Mathf.Pi * 0.7f, Mathf.Pi * 2.3f, 16, 
+                   IsPoweredOn ? new Color(0.0f, 0.8f, 0.0f, 1.0f) : new Color(0.8f, 0.0f, 0.0f, 1.0f), 2);
+            DrawLine(powerCenter, new Vector2(powerCenter.X, powerCenter.Y - powerSymbolRadius * 1.2f), 
+                    IsPoweredOn ? new Color(0.0f, 0.8f, 0.0f, 1.0f) : new Color(0.8f, 0.0f, 0.0f, 1.0f), 2);
+            
+            DrawString(ThemeDB.FallbackFont, 
+                      new Vector2(_powerButtonRect.Position.X + _powerButtonRect.Size.X / 2, 
+                                 _powerButtonRect.Position.Y - 10), 
+                      "POWER", HorizontalAlignment.Center, -1, 14, TextColor);
+            
+            // Draw scan button
+            Color scanBgColor = _scanButtonHovered ? ButtonHighlightColor : ButtonColor;
+            DrawRect(_scanButtonRect, scanBgColor);
+            DrawRect(_scanButtonRect, BorderColor, false, 1);
+            
+            // Draw scan symbol (triangles)
+            float triangleSize = _scanButtonRect.Size.X * 0.3f;
+            Vector2 scanCenter = new Vector2(_scanButtonRect.Position.X + _scanButtonRect.Size.X / 2, 
+                                           _scanButtonRect.Position.Y + _scanButtonRect.Size.Y / 2);
+            
+            Vector2[] leftTriangle = new Vector2[]
+            {
+                new Vector2(scanCenter.X - triangleSize, scanCenter.Y),
+                new Vector2(scanCenter.X - triangleSize / 2, scanCenter.Y - triangleSize / 2),
+                new Vector2(scanCenter.X - triangleSize / 2, scanCenter.Y + triangleSize / 2)
+            };
+            
+            Vector2[] rightTriangle = new Vector2[]
+            {
+                new Vector2(scanCenter.X + triangleSize, scanCenter.Y),
+                new Vector2(scanCenter.X + triangleSize / 2, scanCenter.Y - triangleSize / 2),
+                new Vector2(scanCenter.X + triangleSize / 2, scanCenter.Y + triangleSize / 2)
+            };
+            
+            Color scanSymbolColor = IsPoweredOn ? TextColor : new Color(TextColor, 0.3f);
+            DrawPolygon(leftTriangle, new Color[] { scanSymbolColor });
+            DrawPolygon(rightTriangle, new Color[] { scanSymbolColor });
+            
+            DrawString(ThemeDB.FallbackFont, 
+                      new Vector2(_scanButtonRect.Position.X + _scanButtonRect.Size.X / 2, 
+                                 _scanButtonRect.Position.Y - 10), 
+                      "SCAN", HorizontalAlignment.Center, -1, 14, TextColor);
+            
+            // Draw message button
+            Color messageBgColor = _messageButtonHovered ? ButtonHighlightColor : ButtonColor;
+            DrawRect(_messageButtonRect, messageBgColor);
+            DrawRect(_messageButtonRect, BorderColor, false, 1);
+            
+            // Draw message symbol (envelope)
+            Vector2 msgCenter = new Vector2(_messageButtonRect.Position.X + _messageButtonRect.Size.X / 2, 
+                                          _messageButtonRect.Position.Y + _messageButtonRect.Size.Y / 2);
+            float envelopeWidth = _messageButtonRect.Size.X * 0.6f;
+            float envelopeHeight = _messageButtonRect.Size.Y * 0.4f;
+            
+            Vector2 envelopeTopLeft = new Vector2(msgCenter.X - envelopeWidth / 2, msgCenter.Y - envelopeHeight / 2);
+            Vector2 envelopeTopRight = new Vector2(msgCenter.X + envelopeWidth / 2, msgCenter.Y - envelopeHeight / 2);
+            Vector2 envelopeBottomLeft = new Vector2(msgCenter.X - envelopeWidth / 2, msgCenter.Y + envelopeHeight / 2);
+            Vector2 envelopeBottomRight = new Vector2(msgCenter.X + envelopeWidth / 2, msgCenter.Y + envelopeHeight / 2);
+            
+            Color messageSymbolColor = IsPoweredOn && _messageAvailable ? TextColor : new Color(TextColor, 0.3f);
+            
+            // Draw envelope outline
+            DrawLine(envelopeTopLeft, envelopeTopRight, messageSymbolColor, 1);
+            DrawLine(envelopeTopRight, envelopeBottomRight, messageSymbolColor, 1);
+            DrawLine(envelopeBottomRight, envelopeBottomLeft, messageSymbolColor, 1);
+            DrawLine(envelopeBottomLeft, envelopeTopLeft, messageSymbolColor, 1);
+            
+            // Draw envelope diagonals
+            DrawLine(envelopeTopLeft, envelopeBottomRight, messageSymbolColor, 1);
+            DrawLine(envelopeTopRight, envelopeBottomLeft, messageSymbolColor, 1);
+            
+            DrawString(ThemeDB.FallbackFont, 
+                      new Vector2(_messageButtonRect.Position.X + _messageButtonRect.Size.X / 2, 
+                                 _messageButtonRect.Position.Y - 10), 
+                      "MSG", HorizontalAlignment.Center, -1, 14, TextColor);
+        }
+        
+        // Set the signal strength (0.0 to 1.0)
+        public void SetSignalStrength(float strength)
+        {
+            SignalStrength = Mathf.Clamp(strength, 0.0f, 1.0f);
+            QueueRedraw();
+        }
+        
+        // Set whether a message is available
+        public void SetMessageAvailable(bool available)
+        {
+            _messageAvailable = available;
+            QueueRedraw();
+        }
+        
+        // Set the current frequency
+        public void SetFrequency(float frequency)
+        {
+            CurrentFrequency = Mathf.Clamp(frequency, MinFrequency, MaxFrequency);
+            
+            // Update dial rotation based on frequency
+            float frequencyRange = MaxFrequency - MinFrequency;
+            float normalizedFrequency = (CurrentFrequency - MinFrequency) / frequencyRange;
+            _dialRotation = normalizedFrequency * Mathf.Pi * 2;
+            
+            QueueRedraw();
+        }
+        
+        // Handle resize
+        public override void _Notification(int what)
+        {
+            if (what == NotificationResized)
+            {
+                UpdateUIRects();
+                QueueRedraw();
+            }
+        }
+    }
+}

--- a/scripts/ui/RadioInterfaceManager.cs
+++ b/scripts/ui/RadioInterfaceManager.cs
@@ -1,0 +1,313 @@
+using Godot;
+using System;
+using SignalLost;
+
+namespace SignalLost.UI
+{
+    /// <summary>
+    /// Manages the integration between the PixelRadioInterface and the game's radio systems.
+    /// </summary>
+    [GlobalClass]
+    public partial class RadioInterfaceManager : Node
+    {
+        // References to game systems
+        private GameState _gameState;
+        private RadioSystem _radioSystem;
+        
+        // Reference to the radio interface
+        [Export] public NodePath RadioInterfacePath { get; set; }
+        private PixelRadioInterface _radioInterface;
+        
+        // Signal handling
+        private string _currentSignalId;
+        private bool _messageAvailable = false;
+        
+        // Called when the node enters the scene tree
+        public override void _Ready()
+        {
+            // Get references to game systems
+            _gameState = GetNode<GameState>("/root/GameState");
+            _radioSystem = GetNode<RadioSystem>("/root/RadioSystem");
+            
+            if (_gameState == null)
+            {
+                GD.PrintErr("RadioInterfaceManager: GameState not found");
+                return;
+            }
+            
+            if (_radioSystem == null)
+            {
+                GD.PrintErr("RadioInterfaceManager: RadioSystem not found");
+                return;
+            }
+            
+            // Get reference to radio interface
+            if (RadioInterfacePath != null && !RadioInterfacePath.IsEmpty)
+            {
+                _radioInterface = GetNode<PixelRadioInterface>(RadioInterfacePath);
+            }
+            else
+            {
+                // Try to find the radio interface as a child
+                foreach (Node child in GetChildren())
+                {
+                    if (child is PixelRadioInterface radioInterface)
+                    {
+                        _radioInterface = radioInterface;
+                        break;
+                    }
+                }
+            }
+            
+            if (_radioInterface == null)
+            {
+                GD.PrintErr("RadioInterfaceManager: PixelRadioInterface not found");
+                return;
+            }
+            
+            // Connect signals from radio interface
+            _radioInterface.FrequencyChanged += OnFrequencyChanged;
+            _radioInterface.PowerToggle += OnPowerToggle;
+            _radioInterface.ScanRequested += OnScanRequested;
+            _radioInterface.MessageRequested += OnMessageRequested;
+            
+            // Connect signals from game systems
+            _gameState.FrequencyChanged += OnGameStateFrequencyChanged;
+            _gameState.RadioToggled += OnGameStateRadioToggled;
+            _gameState.SignalDiscovered += OnSignalDiscovered;
+            
+            if (_radioSystem != null)
+            {
+                _radioSystem.SignalDetected += OnSignalDetected;
+                _radioSystem.SignalLost += OnSignalLost;
+            }
+            
+            // Initialize the radio interface with current game state
+            SyncWithGameState();
+        }
+        
+        // Sync the radio interface with the current game state
+        private void SyncWithGameState()
+        {
+            if (_gameState == null || _radioInterface == null) return;
+            
+            // Set frequency
+            _radioInterface.SetFrequency(_gameState.CurrentFrequency);
+            
+            // Set power state
+            _radioInterface.IsPoweredOn = _gameState.IsRadioOn;
+            
+            // Set signal strength
+            float signalStrength = 0.0f;
+            if (_radioSystem != null)
+            {
+                signalStrength = _radioSystem.GetSignalStrength();
+            }
+            else
+            {
+                // Fallback to calculating signal strength from GameState
+                var signalData = _gameState.FindSignalAtFrequency(_gameState.CurrentFrequency);
+                if (signalData != null)
+                {
+                    signalStrength = GameState.CalculateSignalStrength(_gameState.CurrentFrequency, signalData);
+                }
+            }
+            _radioInterface.SetSignalStrength(signalStrength);
+            
+            // Check for message availability
+            CheckMessageAvailability();
+            
+            // Redraw the interface
+            _radioInterface.QueueRedraw();
+        }
+        
+        // Process function called every frame
+        public override void _Process(double delta)
+        {
+            // Update signal strength in real-time
+            if (_gameState != null && _radioInterface != null && _gameState.IsRadioOn)
+            {
+                float signalStrength = 0.0f;
+                if (_radioSystem != null)
+                {
+                    signalStrength = _radioSystem.GetSignalStrength();
+                }
+                else
+                {
+                    // Fallback to calculating signal strength from GameState
+                    var signalData = _gameState.FindSignalAtFrequency(_gameState.CurrentFrequency);
+                    if (signalData != null)
+                    {
+                        signalStrength = GameState.CalculateSignalStrength(_gameState.CurrentFrequency, signalData);
+                    }
+                }
+                _radioInterface.SetSignalStrength(signalStrength);
+            }
+        }
+        
+        // Check if a message is available at the current frequency
+        private void CheckMessageAvailability()
+        {
+            if (_gameState == null || _radioInterface == null) return;
+            
+            bool messageAvailable = false;
+            
+            // Check if there's a signal at the current frequency
+            var signalData = _gameState.FindSignalAtFrequency(_gameState.CurrentFrequency);
+            if (signalData != null)
+            {
+                // Check if the signal has a message
+                if (!string.IsNullOrEmpty(signalData.MessageId))
+                {
+                    // Check if the message exists
+                    var message = _gameState.GetMessage(signalData.MessageId);
+                    if (message != null)
+                    {
+                        messageAvailable = true;
+                    }
+                }
+            }
+            
+            // Update the radio interface
+            _messageAvailable = messageAvailable;
+            _radioInterface.SetMessageAvailable(messageAvailable);
+        }
+        
+        // Handle frequency changed from radio interface
+        private void OnFrequencyChanged(float frequency)
+        {
+            if (_gameState == null) return;
+            
+            // Update game state
+            _gameState.SetFrequency(frequency);
+            
+            // Check for message availability
+            CheckMessageAvailability();
+        }
+        
+        // Handle power toggle from radio interface
+        private void OnPowerToggle(bool isPoweredOn)
+        {
+            if (_gameState == null) return;
+            
+            // Only toggle if the state is different
+            if (_gameState.IsRadioOn != isPoweredOn)
+            {
+                _gameState.ToggleRadio();
+            }
+        }
+        
+        // Handle scan requested from radio interface
+        private void OnScanRequested()
+        {
+            if (_gameState == null) return;
+            
+            // Implement frequency scanning
+            // This is a simple implementation that scans through frequencies
+            // until it finds a signal
+            
+            float startFreq = _gameState.CurrentFrequency;
+            float currentFreq = startFreq;
+            float step = 0.1f;
+            bool signalFound = false;
+            
+            // Scan up to 10 MHz in both directions
+            for (int i = 0; i < 100 && !signalFound; i++)
+            {
+                currentFreq += step;
+                
+                // Wrap around if we reach the limits
+                if (currentFreq > 108.0f)
+                {
+                    currentFreq = 88.0f;
+                }
+                
+                // Check if there's a signal at this frequency
+                var signalData = _gameState.FindSignalAtFrequency(currentFreq);
+                if (signalData != null)
+                {
+                    // Found a signal, stop scanning
+                    signalFound = true;
+                    _gameState.SetFrequency(currentFreq);
+                    break;
+                }
+            }
+            
+            // If no signal was found, return to the original frequency
+            if (!signalFound)
+            {
+                _gameState.SetFrequency(startFreq);
+            }
+        }
+        
+        // Handle message requested from radio interface
+        private void OnMessageRequested()
+        {
+            if (_gameState == null || !_messageAvailable) return;
+            
+            // Get the signal at the current frequency
+            var signalData = _gameState.FindSignalAtFrequency(_gameState.CurrentFrequency);
+            if (signalData != null && !string.IsNullOrEmpty(signalData.MessageId))
+            {
+                // Show the message
+                var messageManager = GetNode<MessageManager>("/root/MessageManager");
+                if (messageManager != null)
+                {
+                    messageManager.ShowMessage(signalData.MessageId);
+                }
+                else
+                {
+                    GD.Print($"Message content: {_gameState.GetMessage(signalData.MessageId)?.Content}");
+                }
+            }
+        }
+        
+        // Handle frequency changed from game state
+        private void OnGameStateFrequencyChanged(float frequency)
+        {
+            if (_radioInterface == null) return;
+            
+            // Update radio interface
+            _radioInterface.SetFrequency(frequency);
+            
+            // Check for message availability
+            CheckMessageAvailability();
+        }
+        
+        // Handle radio toggled from game state
+        private void OnGameStateRadioToggled(bool isOn)
+        {
+            if (_radioInterface == null) return;
+            
+            // Update radio interface
+            _radioInterface.IsPoweredOn = isOn;
+            _radioInterface.QueueRedraw();
+            
+            // Check for message availability
+            CheckMessageAvailability();
+        }
+        
+        // Handle signal detected from radio system
+        private void OnSignalDetected(string signalId, float frequency)
+        {
+            _currentSignalId = signalId;
+            CheckMessageAvailability();
+        }
+        
+        // Handle signal lost from radio system
+        private void OnSignalLost(string signalId)
+        {
+            if (_currentSignalId == signalId)
+            {
+                _currentSignalId = null;
+                CheckMessageAvailability();
+            }
+        }
+        
+        // Handle signal discovered from game state
+        private void OnSignalDiscovered(string signalId, float frequency)
+        {
+            CheckMessageAvailability();
+        }
+    }
+}

--- a/take_pixel_drawing_screenshot.sh
+++ b/take_pixel_drawing_screenshot.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Take a screenshot of the pixel drawing demo
+/Applications/Godot_mono.app/Contents/MacOS/Godot --path . --script scripts/utils/TakeScreenshot.cs -- "pixel_drawing_$(date +%Y%m%d_%H%M%S)"
+
+echo "Screenshot saved to ~/Library/Application Support/Godot/app_userdata/Signal Lost/Screenshots/"
+echo "You can view the most recent screenshot with: open ~/Library/Application\ Support/Godot/app_userdata/Signal\ Lost/Screenshots/pixel_drawing_*.png"


### PR DESCRIPTION
This PR integrates the pixel-based radio interface with the game's radio and signal systems. It includes:

1. A RadioInterfaceManager that connects the PixelRadioInterface with the game's RadioSystem and GameState
2. A demo scene to showcase the integrated radio interface
3. A DemoInitializer script to set up the demo environment with test signals and messages
4. A run script to easily launch the demo

The integration enables:
- Syncing the radio interface with the game state (frequency, power, signal strength)
- Handling user interactions (tuning, power toggle, scanning, message viewing)
- Real-time signal strength updates
- Message availability indication
- Automatic frequency scanning

This builds upon the previous PR that added the pixel-based radio interface visuals.