### PR TITLE
Fix radio interface and add run scripts for different radio scenes

### DIFF
--- a/godot_project/Scenes/MainGameScene.tscn
+++ b/godot_project/Scenes/MainGameScene.tscn
@@ -1,0 +1,140 @@
+[gd_scene load_steps=10 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/PixelRadioInterface.cs" id="1_radio"]
+[ext_resource type="Script" path="res://scripts/ui/RadioInterfaceManager.cs" id="2_manager"]
+[ext_resource type="Script" path="res://scripts/audio/RadioAudioManager.cs" id="3_audio"]
+[ext_resource type="Script" path="res://scripts/MainGameController.cs" id="4_controller"]
+[ext_resource type="Script" path="res://scripts/PixelInventoryUI.cs" id="5_inventory"]
+[ext_resource type="Script" path="res://scripts/PixelMapInterface.cs" id="6_map"]
+[ext_resource type="Script" path="res://scripts/PixelQuestUI.cs" id="7_quest"]
+[ext_resource type="Script" path="res://scripts/SaveLoadMenu.cs" id="8_save"]
+[ext_resource type="Script" path="res://scripts/ProgressionUI.cs" id="9_progression"]
+
+[node name="MainGameScene" type="Node"]
+script = ExtResource("4_controller")
+
+[node name="Background" type="ColorRect" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.1, 0.1, 0.1, 1.0)
+
+[node name="PixelRadioInterface" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_radio")
+
+[node name="RadioInterfaceManager" type="Node" parent="."]
+script = ExtResource("2_manager")
+RadioInterfacePath = NodePath("../PixelRadioInterface")
+
+[node name="RadioAudioManager" type="Node" parent="."]
+script = ExtResource("3_audio")
+
+[node name="PixelInventoryUI" type="Control" parent="."]
+visible = false
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("5_inventory")
+
+[node name="PixelMapInterface" type="Control" parent="."]
+visible = false
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("6_map")
+
+[node name="PixelQuestUI" type="Control" parent="."]
+visible = false
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("7_quest")
+
+[node name="UIControls" type="HBoxContainer" parent="."]
+anchors_preset = 12
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -50.0
+grow_horizontal = 2
+grow_vertical = 0
+alignment = 1
+
+[node name="RadioButton" type="Button" parent="UIControls"]
+layout_mode = 2
+text = "Radio"
+
+[node name="InventoryButton" type="Button" parent="UIControls"]
+layout_mode = 2
+text = "Inventory"
+
+[node name="MapButton" type="Button" parent="UIControls"]
+layout_mode = 2
+text = "Map"
+
+[node name="QuestButton" type="Button" parent="UIControls"]
+layout_mode = 2
+text = "Quests"
+
+[node name="SaveLoadButton" type="Button" parent="UIControls"]
+layout_mode = 2
+text = "Save/Load"
+
+[node name="ProgressionButton" type="Button" parent="UIControls"]
+layout_mode = 2
+text = "Progress"
+
+[node name="SaveLoadMenu" type="Control" parent="."]
+visible = false
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("8_save")
+
+[node name="ProgressionUI" type="Control" parent="."]
+visible = false
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("9_progression")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="ProgressionUI"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+alignment = 1
+
+[node name="StageLabel" type="Label" parent="ProgressionUI/VBoxContainer"]
+layout_mode = 2
+text = "Stage: Beginning"
+horizontal_alignment = 1
+
+[node name="ProgressBar" type="ProgressBar" parent="ProgressionUI/VBoxContainer"]
+layout_mode = 2
+value = 10.0

--- a/godot_project/project.godot
+++ b/godot_project/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="Signal Lost"
-run/main_scene="res://scenes/gameplay/Main.tscn"
+run/main_scene="res://scenes/gameplay/MainMenu.tscn"
 config/features=PackedStringArray("4.4", "C#", "Forward Plus")
 config/icon="res://icon.svg"
 
@@ -28,6 +28,7 @@ SaveManager="*res://scripts/SaveManager.cs"
 GameProgressionManager="*res://scripts/GameProgressionManager.cs"
 GameplayManager="*res://scripts/gameplay/GameplayManager.cs"
 RadioSignalsManager="*res://scripts/radio/RadioSignalsManager.cs"
+RadioAudioManager="*res://scripts/audio/RadioAudioManager.cs"
 
 [display]
 

--- a/godot_project/scripts/MainGameController.cs
+++ b/godot_project/scripts/MainGameController.cs
@@ -1,0 +1,175 @@
+using Godot;
+using System;
+using SignalLost.UI;
+using SignalLost.Audio;
+
+namespace SignalLost
+{
+    /// <summary>
+    /// Main controller for the game scene, handling UI navigation and system integration.
+    /// </summary>
+    [GlobalClass]
+    public partial class MainGameController : Node
+    {
+        // References to UI components
+        private PixelRadioInterface _radioInterface;
+        private PixelInventoryUI _inventoryUI;
+        private PixelMapInterface _mapInterface;
+        private PixelQuestUI _questUI;
+        private SaveLoadMenu _saveLoadMenu;
+        private ProgressionUI _progressionUI;
+        
+        // References to managers
+        private RadioInterfaceManager _radioInterfaceManager;
+        private RadioAudioManager _radioAudioManager;
+        
+        // References to UI control buttons
+        private Button _radioButton;
+        private Button _inventoryButton;
+        private Button _mapButton;
+        private Button _questButton;
+        private Button _saveLoadButton;
+        private Button _progressionButton;
+        
+        // References to game systems
+        private GameState _gameState;
+        private RadioSystem _radioSystem;
+        private InventorySystem _inventorySystem;
+        private MapSystem _mapSystem;
+        private SaveManager _saveManager;
+        
+        // Called when the node enters the scene tree
+        public override void _Ready()
+        {
+            GD.Print("MainGameController: Initializing...");
+            
+            try
+            {
+                // Get references to UI components
+                _radioInterface = GetNode<PixelRadioInterface>("PixelRadioInterface");
+                _inventoryUI = GetNode<PixelInventoryUI>("PixelInventoryUI");
+                _mapInterface = GetNode<PixelMapInterface>("PixelMapInterface");
+                _questUI = GetNode<PixelQuestUI>("PixelQuestUI");
+                _saveLoadMenu = GetNode<SaveLoadMenu>("SaveLoadMenu");
+                _progressionUI = GetNode<ProgressionUI>("ProgressionUI");
+                
+                // Get references to managers
+                _radioInterfaceManager = GetNode<RadioInterfaceManager>("RadioInterfaceManager");
+                _radioAudioManager = GetNode<RadioAudioManager>("RadioAudioManager");
+                
+                // Get references to UI control buttons
+                _radioButton = GetNode<Button>("UIControls/RadioButton");
+                _inventoryButton = GetNode<Button>("UIControls/InventoryButton");
+                _mapButton = GetNode<Button>("UIControls/MapButton");
+                _questButton = GetNode<Button>("UIControls/QuestButton");
+                _saveLoadButton = GetNode<Button>("UIControls/SaveLoadButton");
+                _progressionButton = GetNode<Button>("UIControls/ProgressionButton");
+                
+                // Get references to game systems
+                _gameState = GetNode<GameState>("/root/GameState");
+                _radioSystem = GetNode<RadioSystem>("/root/RadioSystem");
+                _inventorySystem = GetNode<InventorySystem>("/root/InventorySystem");
+                _mapSystem = GetNode<MapSystem>("/root/MapSystem");
+                _saveManager = GetNode<SaveManager>("/root/SaveManager");
+                
+                // Connect button signals
+                _radioButton.Pressed += () => ShowInterface("radio");
+                _inventoryButton.Pressed += () => ShowInterface("inventory");
+                _mapButton.Pressed += () => ShowInterface("map");
+                _questButton.Pressed += () => ShowInterface("quest");
+                _saveLoadButton.Pressed += ToggleSaveLoadMenu;
+                _progressionButton.Pressed += ToggleProgressionUI;
+                
+                // Set up keyboard shortcuts
+                SetProcessInput(true);
+                
+                // Show radio interface by default
+                ShowInterface("radio");
+                
+                GD.Print("MainGameController: Initialization complete");
+            }
+            catch (Exception ex)
+            {
+                GD.PrintErr($"MainGameController: Error during initialization: {ex.Message}");
+                GD.PrintErr(ex.StackTrace);
+            }
+        }
+        
+        // Process input events
+        public override void _Input(InputEvent @event)
+        {
+            if (@event is InputEventKey keyEvent && keyEvent.Pressed)
+            {
+                if (keyEvent.Keycode == Key.R)
+                {
+                    ShowInterface("radio");
+                }
+                else if (keyEvent.Keycode == Key.I)
+                {
+                    ShowInterface("inventory");
+                }
+                else if (keyEvent.Keycode == Key.M)
+                {
+                    ShowInterface("map");
+                }
+                else if (keyEvent.Keycode == Key.Q)
+                {
+                    ShowInterface("quest");
+                }
+                else if (keyEvent.Keycode == Key.S)
+                {
+                    ToggleSaveLoadMenu();
+                }
+                else if (keyEvent.Keycode == Key.P)
+                {
+                    ToggleProgressionUI();
+                }
+            }
+        }
+        
+        // Show the specified interface
+        private void ShowInterface(string interfaceType)
+        {
+            // Hide all interfaces
+            _radioInterface.Visible = false;
+            _inventoryUI.Visible = false;
+            _mapInterface.Visible = false;
+            _questUI.Visible = false;
+            _saveLoadMenu.Visible = false;
+            _progressionUI.Visible = false;
+            
+            // Show the specified interface
+            switch (interfaceType.ToLower())
+            {
+                case "radio":
+                    _radioInterface.Visible = true;
+                    break;
+                case "inventory":
+                    _inventoryUI.Visible = true;
+                    break;
+                case "map":
+                    _mapInterface.Visible = true;
+                    break;
+                case "quest":
+                    _questUI.Visible = true;
+                    break;
+                default:
+                    // Default to radio interface
+                    _radioInterface.Visible = true;
+                    break;
+            }
+        }
+        
+        // Toggle the save/load menu
+        private void ToggleSaveLoadMenu()
+        {
+            _saveLoadMenu.Visible = !_saveLoadMenu.Visible;
+        }
+        
+        // Toggle the progression UI
+        private void ToggleProgressionUI()
+        {
+            _progressionUI.Visible = !_progressionUI.Visible;
+        }
+    }
+}

--- a/godot_project/scripts/audio/RadioAudioManager.cs
+++ b/godot_project/scripts/audio/RadioAudioManager.cs
@@ -1,0 +1,325 @@
+using Godot;
+using System;
+using SignalLost;
+
+namespace SignalLost.Audio
+{
+    /// <summary>
+    /// Manages audio effects and playback for the radio interface.
+    /// </summary>
+    [GlobalClass]
+    public partial class RadioAudioManager : Node
+    {
+        // References to game systems
+        private AudioManager _audioManager;
+        private GameState _gameState;
+        private RadioSystem _radioSystem;
+        
+        // Audio state
+        private float _currentFrequency = 90.0f;
+        private float _signalStrength = 0.0f;
+        private bool _isRadioOn = false;
+        private bool _isTuning = false;
+        
+        // Audio parameters
+        [Export] public float TuningNoiseIntensity { get; set; } = 0.3f;
+        [Export] public float StaticBaseIntensity { get; set; } = 0.1f;
+        [Export] public float SignalQualityThreshold { get; set; } = 0.7f;
+        [Export] public float UIVolume { get; set; } = 0.8f;
+        
+        // Audio effects
+        private AudioStreamPlayer _uiSoundPlayer;
+        private AudioStreamPlayer _tuningNoisePlayer;
+        private Timer _tuningNoiseTimer;
+        
+        // Audio resources
+        private AudioStream _clickSound;
+        private AudioStream _knobSound;
+        private AudioStream _sliderSound;
+        
+        // Called when the node enters the scene tree
+        public override void _Ready()
+        {
+            // Get references to game systems
+            _audioManager = GetNode<AudioManager>("/root/AudioManager");
+            _gameState = GetNode<GameState>("/root/GameState");
+            _radioSystem = GetNode<RadioSystem>("/root/RadioSystem");
+            
+            if (_audioManager == null)
+            {
+                GD.PrintErr("RadioAudioManager: AudioManager not found");
+                return;
+            }
+            
+            // Create audio players
+            _uiSoundPlayer = new AudioStreamPlayer();
+            _uiSoundPlayer.Name = "UISoundPlayer";
+            _uiSoundPlayer.VolumeDb = Mathf.LinearToDb(UIVolume);
+            AddChild(_uiSoundPlayer);
+            
+            _tuningNoisePlayer = new AudioStreamPlayer();
+            _tuningNoisePlayer.Name = "TuningNoisePlayer";
+            _tuningNoisePlayer.VolumeDb = Mathf.LinearToDb(TuningNoiseIntensity);
+            AddChild(_tuningNoisePlayer);
+            
+            // Create tuning noise timer
+            _tuningNoiseTimer = new Timer();
+            _tuningNoiseTimer.Name = "TuningNoiseTimer";
+            _tuningNoiseTimer.WaitTime = 0.1f;
+            _tuningNoiseTimer.OneShot = false;
+            _tuningNoiseTimer.Timeout += OnTuningNoiseTimerTimeout;
+            AddChild(_tuningNoiseTimer);
+            
+            // Load audio resources
+            LoadAudioResources();
+            
+            // Connect to game state signals if available
+            if (_gameState != null)
+            {
+                _gameState.FrequencyChanged += OnFrequencyChanged;
+                _gameState.RadioToggled += OnRadioToggled;
+            }
+            
+            GD.Print("RadioAudioManager initialized");
+        }
+        
+        // Load audio resources
+        private void LoadAudioResources()
+        {
+            try
+            {
+                _clickSound = GD.Load<AudioStream>("res://assets/audio/click.wav");
+                _knobSound = GD.Load<AudioStream>("res://assets/audio/knob.wav");
+                _sliderSound = GD.Load<AudioStream>("res://assets/audio/slider.wav");
+                
+                if (_clickSound == null) GD.PrintErr("RadioAudioManager: Failed to load click.wav");
+                if (_knobSound == null) GD.PrintErr("RadioAudioManager: Failed to load knob.wav");
+                if (_sliderSound == null) GD.PrintErr("RadioAudioManager: Failed to load slider.wav");
+            }
+            catch (Exception ex)
+            {
+                GD.PrintErr($"RadioAudioManager: Error loading audio resources: {ex.Message}");
+            }
+        }
+        
+        // Play UI sound effect
+        public void PlayUISound(string soundType)
+        {
+            if (_uiSoundPlayer == null) return;
+            
+            AudioStream sound = null;
+            
+            switch (soundType.ToLower())
+            {
+                case "click":
+                    sound = _clickSound;
+                    break;
+                case "knob":
+                    sound = _knobSound;
+                    break;
+                case "slider":
+                    sound = _sliderSound;
+                    break;
+                default:
+                    GD.PrintErr($"RadioAudioManager: Unknown sound type: {soundType}");
+                    return;
+            }
+            
+            if (sound != null)
+            {
+                _uiSoundPlayer.Stream = sound;
+                _uiSoundPlayer.Play();
+            }
+        }
+        
+        // Start tuning noise
+        public void StartTuning()
+        {
+            if (!_isRadioOn) return;
+            
+            _isTuning = true;
+            
+            // Start the tuning noise timer
+            _tuningNoiseTimer.Start();
+            
+            // Play initial tuning noise
+            PlayTuningNoise();
+        }
+        
+        // Stop tuning noise
+        public void StopTuning()
+        {
+            _isTuning = false;
+            
+            // Stop the tuning noise timer
+            _tuningNoiseTimer.Stop();
+            
+            // Update audio based on current state
+            UpdateAudio();
+        }
+        
+        // Play tuning noise
+        private void PlayTuningNoise()
+        {
+            if (_audioManager == null) return;
+            
+            // Increase static noise during tuning
+            float staticIntensity = 1.0f - _signalStrength;
+            staticIntensity = Mathf.Clamp(staticIntensity + TuningNoiseIntensity, 0.0f, 1.0f);
+            
+            _audioManager.PlayStaticNoise(staticIntensity);
+            
+            // Reduce signal volume during tuning
+            if (_signalStrength > 0.0f)
+            {
+                float signalVolume = _signalStrength * (1.0f - TuningNoiseIntensity);
+                _audioManager.PlaySignal(_currentFrequency * 10, signalVolume, "sine", _signalStrength > SignalQualityThreshold);
+            }
+        }
+        
+        // Update audio based on current state
+        private void UpdateAudio()
+        {
+            if (_audioManager == null) return;
+            
+            if (_isRadioOn)
+            {
+                if (_isTuning)
+                {
+                    // Already handled in PlayTuningNoise
+                    PlayTuningNoise();
+                }
+                else
+                {
+                    // Normal audio playback
+                    if (_signalStrength > 0.1f)
+                    {
+                        // Play signal with appropriate volume
+                        _audioManager.PlaySignal(_currentFrequency * 10, _signalStrength, "sine", _signalStrength > SignalQualityThreshold);
+                        _audioManager.PlayStaticNoise(1.0f - _signalStrength);
+                    }
+                    else
+                    {
+                        // Just play static
+                        _audioManager.StopSignal();
+                        _audioManager.PlayStaticNoise(1.0f);
+                    }
+                }
+            }
+            else
+            {
+                // Stop all audio when radio is off
+                _audioManager.StopSignal();
+                _audioManager.StopStaticNoise();
+            }
+        }
+        
+        // Handle frequency changed
+        private void OnFrequencyChanged(float frequency)
+        {
+            _currentFrequency = frequency;
+            
+            // Update signal strength
+            if (_radioSystem != null)
+            {
+                _signalStrength = _radioSystem.GetSignalStrength();
+            }
+            else if (_gameState != null)
+            {
+                var signalData = _gameState.FindSignalAtFrequency(frequency);
+                if (signalData != null)
+                {
+                    _signalStrength = GameState.CalculateSignalStrength(frequency, signalData);
+                }
+                else
+                {
+                    _signalStrength = 0.0f;
+                }
+            }
+            
+            // Play knob sound for frequency change
+            PlayUISound("knob");
+            
+            // Update audio
+            UpdateAudio();
+        }
+        
+        // Handle radio toggled
+        private void OnRadioToggled(bool isOn)
+        {
+            _isRadioOn = isOn;
+            
+            // Play power toggle sound
+            PlayUISound("click");
+            
+            if (isOn)
+            {
+                // Play power on squelch
+                if (_audioManager != null)
+                {
+                    _audioManager.PlaySquelchOn();
+                }
+            }
+            else
+            {
+                // Play power off squelch
+                if (_audioManager != null)
+                {
+                    _audioManager.PlaySquelchOff();
+                }
+            }
+            
+            // Update audio
+            UpdateAudio();
+        }
+        
+        // Handle tuning noise timer timeout
+        private void OnTuningNoiseTimerTimeout()
+        {
+            if (_isTuning)
+            {
+                PlayTuningNoise();
+            }
+        }
+        
+        // Set the current frequency and signal strength directly
+        public void SetFrequencyAndSignal(float frequency, float signalStrength)
+        {
+            _currentFrequency = frequency;
+            _signalStrength = signalStrength;
+            
+            // Update audio
+            UpdateAudio();
+        }
+        
+        // Set radio power state directly
+        public void SetRadioPower(bool isOn)
+        {
+            if (_isRadioOn != isOn)
+            {
+                _isRadioOn = isOn;
+                
+                // Update audio
+                UpdateAudio();
+            }
+        }
+        
+        // Play button click sound
+        public void PlayButtonClick()
+        {
+            PlayUISound("click");
+        }
+        
+        // Play dial turn sound
+        public void PlayDialTurn()
+        {
+            PlayUISound("knob");
+        }
+        
+        // Play slider sound
+        public void PlaySliderSound()
+        {
+            PlayUISound("slider");
+        }
+    }
+}

--- a/godot_project/scripts/gameplay/MainMenu.cs
+++ b/godot_project/scripts/gameplay/MainMenu.cs
@@ -62,7 +62,7 @@ namespace SignalLost.Gameplay
             }
 
             // Load the main gameplay scene
-            GetTree().ChangeSceneToFile("res://scenes/gameplay/MainGameplay.tscn");
+            GetTree().ChangeSceneToFile("res://scenes/MainGameScene.tscn");
         }
 
         private void OnLoadGameButtonPressed()
@@ -75,7 +75,7 @@ namespace SignalLost.Gameplay
             }
 
             // Load the main gameplay scene
-            GetTree().ChangeSceneToFile("res://scenes/gameplay/MainGameplay.tscn");
+            GetTree().ChangeSceneToFile("res://scenes/MainGameScene.tscn");
         }
 
         private void OnOptionsButtonPressed()

--- a/godot_project/scripts/ui/PixelRadioInterface.cs
+++ b/godot_project/scripts/ui/PixelRadioInterface.cs
@@ -1,0 +1,480 @@
+using Godot;
+using System;
+using SignalLost.Audio;
+
+namespace SignalLost.UI
+{
+    /// <summary>
+    /// A pixel-based radio interface for the Signal Lost game.
+    /// </summary>
+    [GlobalClass]
+    public partial class PixelRadioInterface : Control
+    {
+        // Configuration
+        [Export] public Color BackgroundColor { get; set; } = new Color(0.1f, 0.1f, 0.1f, 1.0f);
+        [Export] public Color BorderColor { get; set; } = new Color(0.3f, 0.3f, 0.3f, 1.0f);
+        [Export] public Color TextColor { get; set; } = new Color(0.0f, 0.8f, 0.0f, 1.0f);
+        [Export] public Color DialColor { get; set; } = new Color(0.7f, 0.7f, 0.7f, 1.0f);
+        [Export] public Color DialMarkerColor { get; set; } = new Color(0.9f, 0.1f, 0.1f, 1.0f);
+        [Export] public Color ButtonColor { get; set; } = new Color(0.5f, 0.5f, 0.5f, 1.0f);
+        [Export] public Color ButtonHighlightColor { get; set; } = new Color(0.7f, 0.7f, 0.7f, 1.0f);
+        [Export] public Color SignalMeterColor { get; set; } = new Color(0.0f, 0.8f, 0.0f, 1.0f);
+        [Export] public Color SignalMeterBackgroundColor { get; set; } = new Color(0.2f, 0.2f, 0.2f, 1.0f);
+
+        // Radio state
+        [Export] public float MinFrequency { get; set; } = 88.0f;
+        [Export] public float MaxFrequency { get; set; } = 108.0f;
+        [Export] public float CurrentFrequency { get; set; } = 98.0f;
+        [Export] public float SignalStrength { get; set; } = 0.0f;
+        [Export] public bool IsPoweredOn { get; set; } = false;
+
+        // UI elements
+        private Rect2 _tuningDialRect;
+        private Rect2 _frequencyDisplayRect;
+        private Rect2 _signalMeterRect;
+        private Rect2 _powerButtonRect;
+        private Rect2 _scanButtonRect;
+        private Rect2 _messageButtonRect;
+
+        // Interaction state
+        private bool _isDraggingDial = false;
+        private Vector2 _lastMousePosition;
+        private float _dialRotation = 0.0f;
+        private bool _powerButtonHovered = false;
+        private bool _scanButtonHovered = false;
+        private bool _messageButtonHovered = false;
+        private bool _messageAvailable = false;
+
+        // Audio
+        private RadioAudioManager _audioManager;
+
+        // Signals
+        [Signal] public delegate void FrequencyChangedEventHandler(float frequency);
+        [Signal] public delegate void PowerToggleEventHandler(bool isPoweredOn);
+        [Signal] public delegate void ScanRequestedEventHandler();
+        [Signal] public delegate void MessageRequestedEventHandler();
+
+        // Called when the node enters the scene tree
+        public override void _Ready()
+        {
+            // Initialize UI elements
+            UpdateUIRects();
+
+            // Get reference to audio manager
+            _audioManager = GetNode<RadioAudioManager>("/root/RadioAudioManager");
+
+            // If audio manager doesn't exist, try to find it as a sibling
+            if (_audioManager == null)
+            {
+                var parent = GetParent();
+                if (parent != null)
+                {
+                    foreach (Node child in parent.GetChildren())
+                    {
+                        if (child is RadioAudioManager audioManager)
+                        {
+                            _audioManager = audioManager;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Update UI element rectangles based on current size
+        private void UpdateUIRects()
+        {
+            Vector2 size = Size;
+            float width = size.X;
+            float height = size.Y;
+
+            // Calculate radio panel dimensions
+            float panelWidth = width * 0.9f;
+            float panelHeight = height * 0.8f;
+            float panelX = (width - panelWidth) / 2;
+            float panelY = (height - panelHeight) / 2;
+
+            // Tuning dial (circular)
+            float dialSize = Mathf.Min(panelWidth, panelHeight) * 0.4f;
+            float dialX = panelX + panelWidth * 0.25f - dialSize / 2;
+            float dialY = panelY + panelHeight * 0.5f - dialSize / 2;
+            _tuningDialRect = new Rect2(dialX, dialY, dialSize, dialSize);
+
+            // Frequency display
+            float displayWidth = panelWidth * 0.4f;
+            float displayHeight = panelHeight * 0.15f;
+            float displayX = panelX + panelWidth * 0.55f;
+            float displayY = panelY + panelHeight * 0.3f;
+            _frequencyDisplayRect = new Rect2(displayX, displayY, displayWidth, displayHeight);
+
+            // Signal meter
+            float meterWidth = panelWidth * 0.4f;
+            float meterHeight = panelHeight * 0.1f;
+            float meterX = panelX + panelWidth * 0.55f;
+            float meterY = panelY + panelHeight * 0.5f;
+            _signalMeterRect = new Rect2(meterX, meterY, meterWidth, meterHeight);
+
+            // Power button
+            float buttonSize = panelHeight * 0.15f;
+            float powerX = panelX + panelWidth * 0.55f;
+            float powerY = panelY + panelHeight * 0.7f;
+            _powerButtonRect = new Rect2(powerX, powerY, buttonSize, buttonSize);
+
+            // Scan button
+            float scanX = panelX + panelWidth * 0.7f;
+            float scanY = panelY + panelHeight * 0.7f;
+            _scanButtonRect = new Rect2(scanX, scanY, buttonSize, buttonSize);
+
+            // Message button
+            float messageX = panelX + panelWidth * 0.85f;
+            float messageY = panelY + panelHeight * 0.7f;
+            _messageButtonRect = new Rect2(messageX, messageY, buttonSize, buttonSize);
+        }
+
+        // Handle input events
+        public override void _Input(InputEvent @event)
+        {
+            if (@event is InputEventMouseButton mouseButtonEvent)
+            {
+                if (mouseButtonEvent.ButtonIndex == MouseButton.Left)
+                {
+                    Vector2 mousePos = mouseButtonEvent.Position;
+
+                    if (mouseButtonEvent.Pressed)
+                    {
+                        // Check if clicking on tuning dial
+                        if (_tuningDialRect.HasPoint(mousePos))
+                        {
+                            _isDraggingDial = true;
+                            _lastMousePosition = mousePos;
+
+                            // Start tuning audio effect
+                            if (_audioManager != null && IsPoweredOn)
+                            {
+                                _audioManager.StartTuning();
+                                _audioManager.PlayDialTurn();
+                            }
+                        }
+                        // Check if clicking on power button
+                        else if (_powerButtonRect.HasPoint(mousePos))
+                        {
+                            IsPoweredOn = !IsPoweredOn;
+                            EmitSignal(SignalName.PowerToggle, IsPoweredOn);
+
+                            // Play power button sound
+                            if (_audioManager != null)
+                            {
+                                _audioManager.OnRadioToggled(IsPoweredOn);
+                            }
+
+                            QueueRedraw();
+                        }
+                        // Check if clicking on scan button
+                        else if (_scanButtonRect.HasPoint(mousePos) && IsPoweredOn)
+                        {
+                            EmitSignal(SignalName.ScanRequested);
+
+                            // Play button click sound
+                            if (_audioManager != null)
+                            {
+                                _audioManager.PlayButtonClick();
+                            }
+
+                            QueueRedraw();
+                        }
+                        // Check if clicking on message button
+                        else if (_messageButtonRect.HasPoint(mousePos) && IsPoweredOn && _messageAvailable)
+                        {
+                            EmitSignal(SignalName.MessageRequested);
+
+                            // Play button click sound
+                            if (_audioManager != null)
+                            {
+                                _audioManager.PlayButtonClick();
+                            }
+
+                            QueueRedraw();
+                        }
+                    }
+                    else
+                    {
+                        // Stop tuning when mouse button is released
+                        if (_isDraggingDial && _audioManager != null)
+                        {
+                            _audioManager.StopTuning();
+                        }
+
+                        _isDraggingDial = false;
+                    }
+                }
+            }
+            else if (@event is InputEventMouseMotion mouseMotionEvent && _isDraggingDial && IsPoweredOn)
+            {
+                // Calculate dial rotation based on mouse movement
+                Vector2 center = new Vector2(_tuningDialRect.Position.X + _tuningDialRect.Size.X / 2,
+                                           _tuningDialRect.Position.Y + _tuningDialRect.Size.Y / 2);
+
+                Vector2 prevDirection = (_lastMousePosition - center).Normalized();
+                Vector2 newDirection = (mouseMotionEvent.Position - center).Normalized();
+
+                // Calculate angle between previous and new direction
+                float angle = Mathf.Atan2(prevDirection.Cross(newDirection), prevDirection.Dot(newDirection));
+
+                // Update dial rotation
+                _dialRotation += angle;
+                _dialRotation = Mathf.Wrap(_dialRotation, 0, Mathf.Pi * 2);
+
+                // Update frequency based on dial rotation
+                float frequencyRange = MaxFrequency - MinFrequency;
+                float normalizedRotation = _dialRotation / (Mathf.Pi * 2);
+                CurrentFrequency = MinFrequency + normalizedRotation * frequencyRange;
+
+                // Clamp frequency to valid range
+                CurrentFrequency = Mathf.Clamp(CurrentFrequency, MinFrequency, MaxFrequency);
+
+                // Emit signal
+                EmitSignal(SignalName.FrequencyChanged, CurrentFrequency);
+
+                // Update audio manager
+                if (_audioManager != null)
+                {
+                    _audioManager.OnFrequencyChanged(CurrentFrequency);
+                }
+
+                // Update last mouse position
+                _lastMousePosition = mouseMotionEvent.Position;
+
+                // Redraw
+                QueueRedraw();
+            }
+            else if (@event is InputEventMouseMotion mouseMotion)
+            {
+                // Update hover states
+                Vector2 mousePos = mouseMotion.Position;
+                _powerButtonHovered = _powerButtonRect.HasPoint(mousePos);
+                _scanButtonHovered = _scanButtonRect.HasPoint(mousePos) && IsPoweredOn;
+                _messageButtonHovered = _messageButtonRect.HasPoint(mousePos) && IsPoweredOn && _messageAvailable;
+
+                // Redraw if hover state changed
+                QueueRedraw();
+            }
+        }
+
+        // Draw the radio interface
+        public override void _Draw()
+        {
+            Vector2 size = Size;
+
+            // Draw radio panel background
+            float panelWidth = size.X * 0.9f;
+            float panelHeight = size.Y * 0.8f;
+            float panelX = (size.X - panelWidth) / 2;
+            float panelY = (size.Y - panelHeight) / 2;
+
+            DrawRect(new Rect2(panelX, panelY, panelWidth, panelHeight), BackgroundColor);
+            DrawRect(new Rect2(panelX, panelY, panelWidth, panelHeight), BorderColor, false, 2);
+
+            // Draw radio title
+            DrawString(ThemeDB.FallbackFont, new Vector2(size.X / 2, panelY + 30),
+                      "SIGNAL LOST RADIO", HorizontalAlignment.Center, -1, 20, TextColor);
+
+            // Draw frequency display
+            Color displayColor = IsPoweredOn ? TextColor : new Color(TextColor, 0.3f);
+            DrawRect(_frequencyDisplayRect, new Color(0.0f, 0.0f, 0.0f, 1.0f));
+            DrawRect(_frequencyDisplayRect, BorderColor, false, 1);
+
+            string frequencyText = IsPoweredOn ? $"{CurrentFrequency:F1} MHz" : "-- . - MHz";
+            DrawString(ThemeDB.FallbackFont,
+                      new Vector2(_frequencyDisplayRect.Position.X + _frequencyDisplayRect.Size.X / 2,
+                                 _frequencyDisplayRect.Position.Y + _frequencyDisplayRect.Size.Y / 2 + 8),
+                      frequencyText, HorizontalAlignment.Center, -1, 18, displayColor);
+
+            // Draw signal meter
+            DrawRect(_signalMeterRect, SignalMeterBackgroundColor);
+            DrawRect(_signalMeterRect, BorderColor, false, 1);
+
+            if (IsPoweredOn)
+            {
+                float meterFill = _signalMeterRect.Size.X * SignalStrength;
+                DrawRect(new Rect2(_signalMeterRect.Position.X, _signalMeterRect.Position.Y,
+                                  meterFill, _signalMeterRect.Size.Y),
+                        SignalMeterColor);
+            }
+
+            DrawString(ThemeDB.FallbackFont,
+                      new Vector2(_signalMeterRect.Position.X + _signalMeterRect.Size.X / 2,
+                                 _signalMeterRect.Position.Y - 10),
+                      "SIGNAL", HorizontalAlignment.Center, -1, 14, TextColor);
+
+            // Draw tuning dial
+            Vector2 dialCenter = new Vector2(_tuningDialRect.Position.X + _tuningDialRect.Size.X / 2,
+                                           _tuningDialRect.Position.Y + _tuningDialRect.Size.Y / 2);
+            float dialRadius = _tuningDialRect.Size.X / 2;
+
+            // Draw dial background
+            DrawCircle(dialCenter, dialRadius, new Color(0.2f, 0.2f, 0.2f, 1.0f));
+            DrawArc(dialCenter, dialRadius, 0, Mathf.Pi * 2, 32, BorderColor, 2);
+
+            // Draw dial
+            Color actualDialColor = IsPoweredOn ? DialColor : new Color(DialColor, 0.5f);
+            DrawCircle(dialCenter, dialRadius * 0.8f, actualDialColor);
+
+            // Draw dial marker
+            if (IsPoweredOn)
+            {
+                Vector2 markerDirection = Vector2.Right.Rotated(_dialRotation);
+                Vector2 markerStart = dialCenter + markerDirection * (dialRadius * 0.4f);
+                Vector2 markerEnd = dialCenter + markerDirection * (dialRadius * 0.7f);
+                DrawLine(markerStart, markerEnd, DialMarkerColor, 3);
+            }
+
+            // Draw frequency ticks around the dial
+            for (int i = 0; i < 10; i++)
+            {
+                float angle = i * Mathf.Pi * 2 / 10;
+                Vector2 tickDirection = Vector2.Right.Rotated(angle);
+                Vector2 tickStart = dialCenter + tickDirection * (dialRadius * 0.8f);
+                Vector2 tickEnd = dialCenter + tickDirection * dialRadius;
+                DrawLine(tickStart, tickEnd, BorderColor, 1);
+
+                // Draw frequency labels
+                float freq = MinFrequency + (MaxFrequency - MinFrequency) * (i / 10.0f);
+                Vector2 labelPos = dialCenter + tickDirection * (dialRadius * 1.2f);
+                DrawString(ThemeDB.FallbackFont, labelPos, $"{freq:F0}", HorizontalAlignment.Center, -1, 12, TextColor);
+            }
+
+            DrawString(ThemeDB.FallbackFont,
+                      new Vector2(dialCenter.X, _tuningDialRect.Position.Y - 10),
+                      "TUNE", HorizontalAlignment.Center, -1, 14, TextColor);
+
+            // Draw power button
+            Color powerBgColor = _powerButtonHovered ? ButtonHighlightColor : ButtonColor;
+            DrawCircle(new Vector2(_powerButtonRect.Position.X + _powerButtonRect.Size.X / 2,
+                                  _powerButtonRect.Position.Y + _powerButtonRect.Size.Y / 2),
+                      _powerButtonRect.Size.X / 2, powerBgColor);
+
+            // Draw power symbol
+            Vector2 powerCenter = new Vector2(_powerButtonRect.Position.X + _powerButtonRect.Size.X / 2,
+                                            _powerButtonRect.Position.Y + _powerButtonRect.Size.Y / 2);
+            float powerSymbolRadius = _powerButtonRect.Size.X * 0.3f;
+            DrawArc(powerCenter, powerSymbolRadius, Mathf.Pi * 0.7f, Mathf.Pi * 2.3f, 16,
+                   IsPoweredOn ? new Color(0.0f, 0.8f, 0.0f, 1.0f) : new Color(0.8f, 0.0f, 0.0f, 1.0f), 2);
+            DrawLine(powerCenter, new Vector2(powerCenter.X, powerCenter.Y - powerSymbolRadius * 1.2f),
+                    IsPoweredOn ? new Color(0.0f, 0.8f, 0.0f, 1.0f) : new Color(0.8f, 0.0f, 0.0f, 1.0f), 2);
+
+            DrawString(ThemeDB.FallbackFont,
+                      new Vector2(_powerButtonRect.Position.X + _powerButtonRect.Size.X / 2,
+                                 _powerButtonRect.Position.Y - 10),
+                      "POWER", HorizontalAlignment.Center, -1, 14, TextColor);
+
+            // Draw scan button
+            Color scanBgColor = _scanButtonHovered ? ButtonHighlightColor : ButtonColor;
+            DrawRect(_scanButtonRect, scanBgColor);
+            DrawRect(_scanButtonRect, BorderColor, false, 1);
+
+            // Draw scan symbol (triangles)
+            float triangleSize = _scanButtonRect.Size.X * 0.3f;
+            Vector2 scanCenter = new Vector2(_scanButtonRect.Position.X + _scanButtonRect.Size.X / 2,
+                                           _scanButtonRect.Position.Y + _scanButtonRect.Size.Y / 2);
+
+            Vector2[] leftTriangle = new Vector2[]
+            {
+                new Vector2(scanCenter.X - triangleSize, scanCenter.Y),
+                new Vector2(scanCenter.X - triangleSize / 2, scanCenter.Y - triangleSize / 2),
+                new Vector2(scanCenter.X - triangleSize / 2, scanCenter.Y + triangleSize / 2)
+            };
+
+            Vector2[] rightTriangle = new Vector2[]
+            {
+                new Vector2(scanCenter.X + triangleSize, scanCenter.Y),
+                new Vector2(scanCenter.X + triangleSize / 2, scanCenter.Y - triangleSize / 2),
+                new Vector2(scanCenter.X + triangleSize / 2, scanCenter.Y + triangleSize / 2)
+            };
+
+            Color scanSymbolColor = IsPoweredOn ? TextColor : new Color(TextColor, 0.3f);
+            DrawPolygon(leftTriangle, new Color[] { scanSymbolColor });
+            DrawPolygon(rightTriangle, new Color[] { scanSymbolColor });
+
+            DrawString(ThemeDB.FallbackFont,
+                      new Vector2(_scanButtonRect.Position.X + _scanButtonRect.Size.X / 2,
+                                 _scanButtonRect.Position.Y - 10),
+                      "SCAN", HorizontalAlignment.Center, -1, 14, TextColor);
+
+            // Draw message button
+            Color messageBgColor = _messageButtonHovered ? ButtonHighlightColor : ButtonColor;
+            DrawRect(_messageButtonRect, messageBgColor);
+            DrawRect(_messageButtonRect, BorderColor, false, 1);
+
+            // Draw message symbol (envelope)
+            Vector2 msgCenter = new Vector2(_messageButtonRect.Position.X + _messageButtonRect.Size.X / 2,
+                                          _messageButtonRect.Position.Y + _messageButtonRect.Size.Y / 2);
+            float envelopeWidth = _messageButtonRect.Size.X * 0.6f;
+            float envelopeHeight = _messageButtonRect.Size.Y * 0.4f;
+
+            Vector2 envelopeTopLeft = new Vector2(msgCenter.X - envelopeWidth / 2, msgCenter.Y - envelopeHeight / 2);
+            Vector2 envelopeTopRight = new Vector2(msgCenter.X + envelopeWidth / 2, msgCenter.Y - envelopeHeight / 2);
+            Vector2 envelopeBottomLeft = new Vector2(msgCenter.X - envelopeWidth / 2, msgCenter.Y + envelopeHeight / 2);
+            Vector2 envelopeBottomRight = new Vector2(msgCenter.X + envelopeWidth / 2, msgCenter.Y + envelopeHeight / 2);
+
+            Color messageSymbolColor = IsPoweredOn && _messageAvailable ? TextColor : new Color(TextColor, 0.3f);
+
+            // Draw envelope outline
+            DrawLine(envelopeTopLeft, envelopeTopRight, messageSymbolColor, 1);
+            DrawLine(envelopeTopRight, envelopeBottomRight, messageSymbolColor, 1);
+            DrawLine(envelopeBottomRight, envelopeBottomLeft, messageSymbolColor, 1);
+            DrawLine(envelopeBottomLeft, envelopeTopLeft, messageSymbolColor, 1);
+
+            // Draw envelope diagonals
+            DrawLine(envelopeTopLeft, envelopeBottomRight, messageSymbolColor, 1);
+            DrawLine(envelopeTopRight, envelopeBottomLeft, messageSymbolColor, 1);
+
+            DrawString(ThemeDB.FallbackFont,
+                      new Vector2(_messageButtonRect.Position.X + _messageButtonRect.Size.X / 2,
+                                 _messageButtonRect.Position.Y - 10),
+                      "MSG", HorizontalAlignment.Center, -1, 14, TextColor);
+        }
+
+        // Set the signal strength (0.0 to 1.0)
+        public void SetSignalStrength(float strength)
+        {
+            SignalStrength = Mathf.Clamp(strength, 0.0f, 1.0f);
+            QueueRedraw();
+        }
+
+        // Set whether a message is available
+        public void SetMessageAvailable(bool available)
+        {
+            _messageAvailable = available;
+            QueueRedraw();
+        }
+
+        // Set the current frequency
+        public void SetFrequency(float frequency)
+        {
+            CurrentFrequency = Mathf.Clamp(frequency, MinFrequency, MaxFrequency);
+
+            // Update dial rotation based on frequency
+            float frequencyRange = MaxFrequency - MinFrequency;
+            float normalizedFrequency = (CurrentFrequency - MinFrequency) / frequencyRange;
+            _dialRotation = normalizedFrequency * Mathf.Pi * 2;
+
+            // Update audio manager
+            if (_audioManager != null)
+            {
+                _audioManager.OnFrequencyChanged(CurrentFrequency);
+            }
+
+            QueueRedraw();
+        }
+
+        // Handle resize
+        public override void _Notification(int what)
+        {
+            if (what == NotificationResized)
+            {
+                UpdateUIRects();
+                QueueRedraw();
+            }
+        }
+    }
+}

--- a/godot_project/scripts/ui/PixelRadioInterface.cs
+++ b/godot_project/scripts/ui/PixelRadioInterface.cs
@@ -164,7 +164,8 @@ namespace SignalLost.UI
                             // Play power button sound
                             if (_audioManager != null)
                             {
-                                _audioManager.OnRadioToggled(IsPoweredOn);
+                                _audioManager.SetRadioPower(IsPoweredOn);
+                                _audioManager.PlayButtonClick();
                             }
 
                             QueueRedraw();
@@ -238,7 +239,8 @@ namespace SignalLost.UI
                 // Update audio manager
                 if (_audioManager != null)
                 {
-                    _audioManager.OnFrequencyChanged(CurrentFrequency);
+                    _audioManager.SetFrequencyAndSignal(CurrentFrequency, SignalStrength);
+                    _audioManager.PlayDialTurn();
                 }
 
                 // Update last mouse position
@@ -461,7 +463,8 @@ namespace SignalLost.UI
             // Update audio manager
             if (_audioManager != null)
             {
-                _audioManager.OnFrequencyChanged(CurrentFrequency);
+                _audioManager.SetFrequencyAndSignal(CurrentFrequency, SignalStrength);
+                _audioManager.PlayDialTurn();
             }
 
             QueueRedraw();

--- a/godot_project/scripts/ui/RadioInterfaceManager.cs
+++ b/godot_project/scripts/ui/RadioInterfaceManager.cs
@@ -1,0 +1,313 @@
+using Godot;
+using System;
+using SignalLost;
+
+namespace SignalLost.UI
+{
+    /// <summary>
+    /// Manages the integration between the PixelRadioInterface and the game's radio systems.
+    /// </summary>
+    [GlobalClass]
+    public partial class RadioInterfaceManager : Node
+    {
+        // References to game systems
+        private GameState _gameState;
+        private RadioSystem _radioSystem;
+        
+        // Reference to the radio interface
+        [Export] public NodePath RadioInterfacePath { get; set; }
+        private PixelRadioInterface _radioInterface;
+        
+        // Signal handling
+        private string _currentSignalId;
+        private bool _messageAvailable = false;
+        
+        // Called when the node enters the scene tree
+        public override void _Ready()
+        {
+            // Get references to game systems
+            _gameState = GetNode<GameState>("/root/GameState");
+            _radioSystem = GetNode<RadioSystem>("/root/RadioSystem");
+            
+            if (_gameState == null)
+            {
+                GD.PrintErr("RadioInterfaceManager: GameState not found");
+                return;
+            }
+            
+            if (_radioSystem == null)
+            {
+                GD.PrintErr("RadioInterfaceManager: RadioSystem not found");
+                return;
+            }
+            
+            // Get reference to radio interface
+            if (RadioInterfacePath != null && !RadioInterfacePath.IsEmpty)
+            {
+                _radioInterface = GetNode<PixelRadioInterface>(RadioInterfacePath);
+            }
+            else
+            {
+                // Try to find the radio interface as a child
+                foreach (Node child in GetChildren())
+                {
+                    if (child is PixelRadioInterface radioInterface)
+                    {
+                        _radioInterface = radioInterface;
+                        break;
+                    }
+                }
+            }
+            
+            if (_radioInterface == null)
+            {
+                GD.PrintErr("RadioInterfaceManager: PixelRadioInterface not found");
+                return;
+            }
+            
+            // Connect signals from radio interface
+            _radioInterface.FrequencyChanged += OnFrequencyChanged;
+            _radioInterface.PowerToggle += OnPowerToggle;
+            _radioInterface.ScanRequested += OnScanRequested;
+            _radioInterface.MessageRequested += OnMessageRequested;
+            
+            // Connect signals from game systems
+            _gameState.FrequencyChanged += OnGameStateFrequencyChanged;
+            _gameState.RadioToggled += OnGameStateRadioToggled;
+            _gameState.SignalDiscovered += OnSignalDiscovered;
+            
+            if (_radioSystem != null)
+            {
+                _radioSystem.SignalDetected += OnSignalDetected;
+                _radioSystem.SignalLost += OnSignalLost;
+            }
+            
+            // Initialize the radio interface with current game state
+            SyncWithGameState();
+        }
+        
+        // Sync the radio interface with the current game state
+        private void SyncWithGameState()
+        {
+            if (_gameState == null || _radioInterface == null) return;
+            
+            // Set frequency
+            _radioInterface.SetFrequency(_gameState.CurrentFrequency);
+            
+            // Set power state
+            _radioInterface.IsPoweredOn = _gameState.IsRadioOn;
+            
+            // Set signal strength
+            float signalStrength = 0.0f;
+            if (_radioSystem != null)
+            {
+                signalStrength = _radioSystem.GetSignalStrength();
+            }
+            else
+            {
+                // Fallback to calculating signal strength from GameState
+                var signalData = _gameState.FindSignalAtFrequency(_gameState.CurrentFrequency);
+                if (signalData != null)
+                {
+                    signalStrength = GameState.CalculateSignalStrength(_gameState.CurrentFrequency, signalData);
+                }
+            }
+            _radioInterface.SetSignalStrength(signalStrength);
+            
+            // Check for message availability
+            CheckMessageAvailability();
+            
+            // Redraw the interface
+            _radioInterface.QueueRedraw();
+        }
+        
+        // Process function called every frame
+        public override void _Process(double delta)
+        {
+            // Update signal strength in real-time
+            if (_gameState != null && _radioInterface != null && _gameState.IsRadioOn)
+            {
+                float signalStrength = 0.0f;
+                if (_radioSystem != null)
+                {
+                    signalStrength = _radioSystem.GetSignalStrength();
+                }
+                else
+                {
+                    // Fallback to calculating signal strength from GameState
+                    var signalData = _gameState.FindSignalAtFrequency(_gameState.CurrentFrequency);
+                    if (signalData != null)
+                    {
+                        signalStrength = GameState.CalculateSignalStrength(_gameState.CurrentFrequency, signalData);
+                    }
+                }
+                _radioInterface.SetSignalStrength(signalStrength);
+            }
+        }
+        
+        // Check if a message is available at the current frequency
+        private void CheckMessageAvailability()
+        {
+            if (_gameState == null || _radioInterface == null) return;
+            
+            bool messageAvailable = false;
+            
+            // Check if there's a signal at the current frequency
+            var signalData = _gameState.FindSignalAtFrequency(_gameState.CurrentFrequency);
+            if (signalData != null)
+            {
+                // Check if the signal has a message
+                if (!string.IsNullOrEmpty(signalData.MessageId))
+                {
+                    // Check if the message exists
+                    var message = _gameState.GetMessage(signalData.MessageId);
+                    if (message != null)
+                    {
+                        messageAvailable = true;
+                    }
+                }
+            }
+            
+            // Update the radio interface
+            _messageAvailable = messageAvailable;
+            _radioInterface.SetMessageAvailable(messageAvailable);
+        }
+        
+        // Handle frequency changed from radio interface
+        private void OnFrequencyChanged(float frequency)
+        {
+            if (_gameState == null) return;
+            
+            // Update game state
+            _gameState.SetFrequency(frequency);
+            
+            // Check for message availability
+            CheckMessageAvailability();
+        }
+        
+        // Handle power toggle from radio interface
+        private void OnPowerToggle(bool isPoweredOn)
+        {
+            if (_gameState == null) return;
+            
+            // Only toggle if the state is different
+            if (_gameState.IsRadioOn != isPoweredOn)
+            {
+                _gameState.ToggleRadio();
+            }
+        }
+        
+        // Handle scan requested from radio interface
+        private void OnScanRequested()
+        {
+            if (_gameState == null) return;
+            
+            // Implement frequency scanning
+            // This is a simple implementation that scans through frequencies
+            // until it finds a signal
+            
+            float startFreq = _gameState.CurrentFrequency;
+            float currentFreq = startFreq;
+            float step = 0.1f;
+            bool signalFound = false;
+            
+            // Scan up to 10 MHz in both directions
+            for (int i = 0; i < 100 && !signalFound; i++)
+            {
+                currentFreq += step;
+                
+                // Wrap around if we reach the limits
+                if (currentFreq > 108.0f)
+                {
+                    currentFreq = 88.0f;
+                }
+                
+                // Check if there's a signal at this frequency
+                var signalData = _gameState.FindSignalAtFrequency(currentFreq);
+                if (signalData != null)
+                {
+                    // Found a signal, stop scanning
+                    signalFound = true;
+                    _gameState.SetFrequency(currentFreq);
+                    break;
+                }
+            }
+            
+            // If no signal was found, return to the original frequency
+            if (!signalFound)
+            {
+                _gameState.SetFrequency(startFreq);
+            }
+        }
+        
+        // Handle message requested from radio interface
+        private void OnMessageRequested()
+        {
+            if (_gameState == null || !_messageAvailable) return;
+            
+            // Get the signal at the current frequency
+            var signalData = _gameState.FindSignalAtFrequency(_gameState.CurrentFrequency);
+            if (signalData != null && !string.IsNullOrEmpty(signalData.MessageId))
+            {
+                // Show the message
+                var messageManager = GetNode<MessageManager>("/root/MessageManager");
+                if (messageManager != null)
+                {
+                    messageManager.ShowMessage(signalData.MessageId);
+                }
+                else
+                {
+                    GD.Print($"Message content: {_gameState.GetMessage(signalData.MessageId)?.Content}");
+                }
+            }
+        }
+        
+        // Handle frequency changed from game state
+        private void OnGameStateFrequencyChanged(float frequency)
+        {
+            if (_radioInterface == null) return;
+            
+            // Update radio interface
+            _radioInterface.SetFrequency(frequency);
+            
+            // Check for message availability
+            CheckMessageAvailability();
+        }
+        
+        // Handle radio toggled from game state
+        private void OnGameStateRadioToggled(bool isOn)
+        {
+            if (_radioInterface == null) return;
+            
+            // Update radio interface
+            _radioInterface.IsPoweredOn = isOn;
+            _radioInterface.QueueRedraw();
+            
+            // Check for message availability
+            CheckMessageAvailability();
+        }
+        
+        // Handle signal detected from radio system
+        private void OnSignalDetected(string signalId, float frequency)
+        {
+            _currentSignalId = signalId;
+            CheckMessageAvailability();
+        }
+        
+        // Handle signal lost from radio system
+        private void OnSignalLost(string signalId)
+        {
+            if (_currentSignalId == signalId)
+            {
+                _currentSignalId = null;
+                CheckMessageAvailability();
+            }
+        }
+        
+        // Handle signal discovered from game state
+        private void OnSignalDiscovered(string signalId, float frequency)
+        {
+            CheckMessageAvailability();
+        }
+    }
+}

--- a/run_game.sh
+++ b/run_game.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd godot_project
+/Applications/Godot_mono.app/Contents/MacOS/Godot --path .

--- a/run_game_with_radio.sh
+++ b/run_game_with_radio.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd godot_project
+/Applications/Godot_mono.app/Contents/MacOS/Godot --path . --scene scenes/MainGameScene.tscn

--- a/run_radio_demo.sh
+++ b/run_radio_demo.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd godot_project
+/Applications/Godot_mono.app/Contents/MacOS/Godot --path . --scene Scenes/Radio/RadioSignalsDemo.tscn

--- a/run_radio_dial.sh
+++ b/run_radio_dial.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd godot_project
+/Applications/Godot_mono.app/Contents/MacOS/Godot --path . --scene Scenes/Radio/EnhancedRadioDial.tscn

--- a/run_radio_main.sh
+++ b/run_radio_main.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd godot_project
+/Applications/Godot_mono.app/Contents/MacOS/Godot --path . --scene Scenes/Radio/RadioMain.tscn

--- a/run_radio_test.sh
+++ b/run_radio_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd godot_project
+/Applications/Godot_mono.app/Contents/MacOS/Godot --path . --scene Scenes/Radio/RadioSystemIntegrationTest.tscn


### PR DESCRIPTION
This PR fixes the radio interface by:

1. Consolidating the project structure by copying necessary scripts to the godot_project directory
2. Adding RadioAudioManager as an autoload in project.godot
3. Creating run scripts for different radio scenes:
   - run_game.sh: Runs the game from the main menu
   - run_game_with_radio.sh: Runs the game directly with the radio interface
   - run_radio_main.sh: Runs the RadioMain scene
   - run_radio_demo.sh: Runs the RadioSignalsDemo scene
   - run_radio_dial.sh: Runs the EnhancedRadioDial scene
   - run_radio_test.sh: Runs the RadioSystemIntegrationTest scene

These changes make it easier to run and test the radio interface in different configurations.